### PR TITLE
[Propose] Override Sisimai::Address#to_s method for extract e-mail address.

### DIFF
--- a/lib/sisimai/address.rb
+++ b/lib/sisimai/address.rb
@@ -211,6 +211,12 @@ module Sisimai
     # Returns the value of address as String
     # @return [String] Email address
     def to_json
+      return to_s
+    end
+
+    # Returns the value of address as String
+    # @return [String] Email address
+    def to_s
       return self.address.to_s
     end
 


### PR DESCRIPTION
``to_s`` method usually use in ruby programming. 

Override Sisimai::Address#to_s method for extract e-mail address.   

```ruby
#!/usr/bin/env ruby

require 'sisimai'
require 'sisimai/message'
require 'sisimai/data'
require 'pp'

file = File.open("make-test-01.eml")

mesg = Sisimai::Message.new( data: file.read )
data = Sisimai::Data.make( data: mesg )

pp data[0].addresser.to_s

file.close
```

Before


```
"#<Sisimai::Address:0x007fd093a88a70>"
```

After

```
"user1@example.jp"
```