### PR TITLE
[WIP] Split gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sisimai.gemspec
 gemspec
-
-gem 'oj', '>= 2.14.4', :platform => :ruby
-gem 'jrjackson', '>= 0.3.8', :platform => :jruby
-
-group :development, :test do
-  gem 'coveralls', require: false
-end
-

--- a/sisimai-java.gemspec
+++ b/sisimai-java.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Sisimai is a Ruby library for analyzing RFC5322 bounce emails and generating structured data from parsed results.'
   spec.homepage      = 'http://libsisimai.org/'
   spec.license       = 'BSD-2-Clause'
+  spec.platform      = "java"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'
@@ -24,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.8'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
-  spec.add_runtime_dependency 'oj', '>= 2.14.4'
+  spec.add_runtime_dependency 'jrjackson'
 end

--- a/sisimai-java.gemspec
+++ b/sisimai-java.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.8'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec'
-  spec.add_runtime_dependency 'jrjackson'
+  spec.add_development_dependency 'rspec', '~> 0'
+  spec.add_runtime_dependency 'jrjackson','~> 0.3','>= 0.3.8'
 end

--- a/sisimai.gemspec
+++ b/sisimai.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.8'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec'
-  spec.add_runtime_dependency 'oj', '>= 2.14.4'
+  spec.add_development_dependency 'rspec', '~> 0'
+  spec.add_runtime_dependency 'oj', '~> 2.14', '>= 2.14.4'
 end


### PR DESCRIPTION
Create two gemspec, one is for CRuby, the other is for JRuby.
https://github.com/rubygems/rubygems/issues/1492

One problem.

You can't use ``rake build `` command. Alternatively must use ``gem build`` command.
https://github.com/bundler/bundler/issues/2971

```
rake build 
rake aborted!
Unable to determine name from existing gemspec. Use :name => 'gemname' in #install_tasks to manually set it.
/path/to/home/rb-Sisimai/Rakefile:1:in `<top (required)>'
LoadError: cannot load such file -- bundler/gem_tasks
/path/to/home/rb-Sisimai/Rakefile:1:in `<top (required)>'
(See full trace by running task with --trace)
```

And I don't know how to publish gem file without rake publish.
