### PR TITLE
Fix a typo

### DIFF
--- a/Changes
+++ b/Changes
@@ -113,7 +113,7 @@ Revision history for the Ruby version of Sisimai
     - Implement new MTA/MSP module "Sisimai::MSP::US::Office365" to parse error
       mails via Microsoft Office 365. The module, test codes, and sample emails
       are imported from https://github.com/sisimai/p5-Sisimai/pull/164.
-    - New method Sisimai::Address#to_s to get a email address as String, it is
+    - New method Sisimai::Address#to_s to get an email address as String, it is
       implemented at pull-request #39. Thanks to @hiroyuki-sato.
     - Almost all of the class variables are removed for resolving issue #40 and
       merged pull-request #43, thanks to @hiroyuki-sato.

--- a/lib/sisimai/message.rb
+++ b/lib/sisimai/message.rb
@@ -14,7 +14,7 @@ module Sisimai
 
     @@rwaccessors = [
       :from,    # [String] UNIX From line
-      :header,  # [Hash]   Header part of a email
+      :header,  # [Hash]   Header part of an email
       :ds,      # [Array]  Parsed data by Sisimai::MTA::*
       :rfc822,  # [Hash]   Header part of the original message
       :catch,   # [?]      The results returned by hook method

--- a/lib/sisimai/reason/mesgtoobig.rb
+++ b/lib/sisimai/reason/mesgtoobig.rb
@@ -10,7 +10,7 @@ module Sisimai
       class << self
         def text; return 'mesgtoobig'; end
         def description
-          return 'Email rejected due to a email size is too big for a destination mail server'
+          return 'Email rejected due to an email size is too big for a destination mail server'
         end
 
         # Try to match that the given text and regular expressions

--- a/lib/sisimai/rfc5322.rb
+++ b/lib/sisimai/rfc5322.rb
@@ -78,7 +78,7 @@ module Sisimai
 
       # Check that the argument is an email address or not
       # @param    [String] email  Email address string
-      # @return   [True,False]    true: is a email address
+      # @return   [True,False]    true: is an email address
       #                           false: is not an email address
       def is_emailaddress(email)
         return false unless email.is_a?(::String)


### PR DESCRIPTION
Just modified `a email` to `an email`.
