### PR TITLE
Fix hash element initialization

### DIFF
--- a/lib/sisimai/mta/postfix.rb
+++ b/lib/sisimai/mta/postfix.rb
@@ -186,11 +186,13 @@ module Sisimai
                 if cv = e.match(/[ \t][(]in reply to ([A-Z]{4}).*/)
                   # 5.1.1 <userunknown@example.co.jp>... User Unknown (in reply to RCPT TO
                   commandset << cv[1]
+                  anotherset['diagnosis'] ||= ''
                   anotherset['diagnosis'] += ' ' + e
 
                 elsif cv = e.match(/([A-Z]{4})[ \t]*.*command[)]\z/)
                   # to MAIL command)
                   commandset << cv[1]
+                  anotherset['diagnosis'] ||= ''
                   anotherset['diagnosis'] += ' ' + e
 
                 else


### PR DESCRIPTION
Error occurred in Sisimai::MTA::Postfix module.

```
/var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai/mta/postfix.rb:189:in `block in scan': undefined method `+' for nil:NilClass (NoMethodError)
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai/mta/postfix.rb:77:in `each'
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai/mta/postfix.rb:77:in `scan'
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai/message/email.rb:520:in `block (3 levels) in parse'
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai/message/email.rb:510:in `each'
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai/message/email.rb:510:in `block (2 levels) in parse'
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai/message/email.rb:482:in `loop'
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai/message/email.rb:482:in `block in parse'
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai/message/email.rb:481:in `catch'
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai/message/email.rb:481:in `parse'
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai/message/email.rb:87:in `make'
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai/message.rb:86:in `initialize'
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai.rb:65:in `new'
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai.rb:65:in `make'
        from /var/lib/gems/2.3.0/gems/sisimai-4.21.0/lib/sisimai.rb:122:in `dump'
        from -e:1:in `<main>'
```

Initialization processing added, anotherset['diagnosis'] value to empty string.
