### PR TITLE
Subjectに空白が入っているとMIMEデコードに失敗する

### DIFF
--- a/lib/sisimai/message/email.rb
+++ b/lib/sisimai/message/email.rb
@@ -364,7 +364,7 @@ module Sisimai
             r = []
             if mimeborder['subject']
               # split the value of Subject by $borderline
-              v.split(borderline).each do |m|
+              v.split(Regexp.union(borderline, ' ')).each do |m|
                 # Insert value to the array if the string is MIME encoded text
                 r << m if Sisimai::MIME.is_mimeencoded(m)
               end


### PR DESCRIPTION
以下のようにSubjectの途中で空白が入っているとSubjectのMIMEデコードに失敗するようです。

```
$ echo '[TEST] ユーザー登録' | nkf -jM
[TEST] =?ISO-2022-JP?B?GyRCJWYhPCU2ITxFUE8/GyhC?=
```

is_mimeencodedメソッドで「いずれか一つでも正規表現にマッチしない場合、エンコードされていないと見なす」という処理に引っかかって、デコードされないようです。

takeapartメソッドの方で、borderlineだけでなく空白でも分割するようにしてみました。
レビューをお願いします。 🙏 