### PR TITLE
Fix #92.

### DIFF
--- a/lib/sisimai.rb
+++ b/lib/sisimai.rb
@@ -78,7 +78,6 @@ module Sisimai
         if type == 'Array'
           # [ {...}, {...}, ... ]
           argv0.each do |e|
-            next unless e.class.to_s == 'Hash'
             list << e
           end
         else


### PR DESCRIPTION
Make `Sisimai.make(json, input: 'json')` to parse Hash-like(eg: ActiveSupport::HashWithIndifferentAccess).

https://github.com/sisimai/rb-Sisimai/issues/92