### PR TITLE
Less regular expressions in bite email

### DIFF
--- a/lib/sisimai/arf.rb
+++ b/lib/sisimai/arf.rb
@@ -34,7 +34,6 @@ module Sisimai
           )
         }x,
         :rfc822 => %r[\AContent-Type: (:?message/rfc822|text/rfc822-headers)],
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
       LongFields = Sisimai::RFC5322.LONGFIELDS

--- a/lib/sisimai/bite/email/activehunter.rb
+++ b/lib/sisimai/bite/email/activehunter.rb
@@ -15,7 +15,6 @@ module Sisimai::Bite::Email
         :begin   => %r/\A  ----- The following addresses had permanent fatal errors -----\z/,
         :error   => %r/\A  ----- Transcript of session follows -----\z/,
         :rfc822  => %r|\AContent-type: message/rfc822\z|,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/activehunter.rb
+++ b/lib/sisimai/bite/email/activehunter.rb
@@ -7,10 +7,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Activehunter.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from    => %r/\A"MAILER-DAEMON"/,
-        :subject => %r/FAILURE NOTICE :/,
-      }.freeze
       Re1 = {
         :begin   => %r/\A  ----- The following addresses had permanent fatal errors -----\z/,
         :error   => %r/\A  ----- Transcript of session follows -----\z/,
@@ -36,6 +32,9 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
+
+        # :from    => %r/\A"MAILER-DAEMON"/,
+        # :subject => %r/FAILURE NOTICE :/,
         return nil unless mhead['x-ahmailid']
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/amazonses.rb
+++ b/lib/sisimai/bite/email/amazonses.rb
@@ -8,11 +8,6 @@ module Sisimai::Bite::Email
       require 'sisimai/bite/email'
 
       # http://aws.amazon.com/ses/
-      ReE = { :'x-mailer' => %r/Amazon[ ]WorkMail/ }.freeze
-      Re0 = {
-        :from    => %r/\AMAILER-DAEMON[@]email[-]bounces[.]amazonses[.]com\z/,
-        :subject => %r/\ADelivery Status Notification [(]Failure[)]\z/,
-      }.freeze
       Re1 = {
         :begin   => %r/\A(?:
              The[ ]following[ ]message[ ]to[ ][<]
@@ -50,9 +45,11 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
 
-        match = 0
-        return nil if mhead['x-mailer'] =~ ReE[:'x-mailer']
+        # :from    => %r/\AMAILER-DAEMON[@]email[-]bounces[.]amazonses[.]com\z/,
+        # :subject => %r/\ADelivery Status Notification [(]Failure[)]\z/,
+        return nil if mhead['x-mailer'].to_s.include?('Amazon WorkMail')
 
+        match  = 0
         match += 1 if mhead['x-aws-outgoing']
         match += 1 if mhead['x-ses-outgoing']
         return nil if match.zero?

--- a/lib/sisimai/bite/email/amazonses.rb
+++ b/lib/sisimai/bite/email/amazonses.rb
@@ -20,7 +20,6 @@ module Sisimai::Bite::Email
             )
         /x,
         :rfc822  => %r|\Acontent-type: message/rfc822\z|,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         expired: %r/Delivery[ ]expired/x,

--- a/lib/sisimai/bite/email/amazonworkmail.rb
+++ b/lib/sisimai/bite/email/amazonworkmail.rb
@@ -7,11 +7,6 @@ module Sisimai::Bite::Email
       require 'sisimai/bite/email'
 
       # https://aws.amazon.com/workmail/
-      Re0 = {
-        :'subject'  => %r/Delivery[_ ]Status[_ ]Notification[_ ].+Failure/,
-        :'received' => %r/.+[.]smtp-out[.].+[.]amazonses[.]com\b/,
-        :'x-mailer' => %r/\AAmazon WorkMail\z/,
-      }.freeze
       Re1 = {
         :begin  => %r/\ATechnical report:\z/,
         :rfc822 => %r|\Acontent-type: message/rfc822\z|,
@@ -41,6 +36,9 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
 
+        # :'subject'  => %r/Delivery[_ ]Status[_ ]Notification[_ ].+Failure/,
+        # :'received' => %r/.+[.]smtp-out[.].+[.]amazonses[.]com\b/,
+        # :'x-mailer' => %r/\AAmazon WorkMail\z/,
         match = 0
         xmail = mhead['x-original-mailer'] || mhead['x-mailer'] || ''
 
@@ -48,7 +46,7 @@ module Sisimai::Bite::Email
         unless xmail.empty?
           # X-Mailer: Amazon WorkMail
           # X-Original-Mailer: Amazon WorkMail
-          match += 1 if xmail =~ Re0[:'x-mailer']
+          match += 1 if xmail.start_with?('Amazon WorkMail')
         end
         return nil if match < 2
 

--- a/lib/sisimai/bite/email/amazonworkmail.rb
+++ b/lib/sisimai/bite/email/amazonworkmail.rb
@@ -15,7 +15,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin  => %r/\ATechnical report:\z/,
         :rfc822 => %r|\Acontent-type: message/rfc822\z|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/aol.rb
+++ b/lib/sisimai/bite/email/aol.rb
@@ -13,7 +13,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin   => %r|\AContent-Type: message/delivery-status|,
         :rfc822  => %r|\AContent-Type: message/rfc822|,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         hostunknown: %r/Host[ ]or[ ]domain[ ]name[ ]not[ ]found/,

--- a/lib/sisimai/bite/email/aol.rb
+++ b/lib/sisimai/bite/email/aol.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Aol.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from    => %r/\APostmaster [<]Postmaster[@]AOL[.]com[>]\z/,
-        :subject => %r/\AUndeliverable: /,
-      }.freeze
       Re1 = {
         :begin   => %r|\AContent-Type: message/delivery-status|,
         :rfc822  => %r|\AContent-Type: message/rfc822|,
@@ -49,6 +45,9 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
+
+        # :from    => %r/\APostmaster [<]Postmaster[@]AOL[.]com[>]\z/,
+        # :subject => %r/\AUndeliverable: /,
         return nil unless mhead['x-aol-ip']
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/apachejames.rb
+++ b/lib/sisimai/bite/email/apachejames.rb
@@ -6,11 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/ApacheJames.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'subject'    => %r/\A\[BOUNCE\]\z/,
-        :'received'   => %r/JAMES SMTP Server/,
-        :'message-id' => %r/\d+[.]JavaMail[.].+[@]/,
-      }.freeze
       Re1 = {
         # apache-james-2.3.2/src/java/org/apache/james/transport/mailets/
         #   AbstractNotify.java|124:  out.println("Error message below:");
@@ -41,9 +36,9 @@ module Sisimai::Bite::Email
         return nil unless mbody
 
         match  = 0
-        match += 1 if mhead['subject'] =~ Re0[:subject]
-        match += 1 if mhead['message-id'] && mhead['message-id'] =~ Re0[:'message-id']
-        match += 1 if mhead['received'].find { |a| a =~ Re0[:received] }
+        match += 1 if mhead['subject'].start_with?('[BOUNCE]')
+        match += 1 if mhead['message-id'] && mhead['message-id'] =~ /\d+[.]JavaMail[.].+[@]/
+        match += 1 if mhead['received'].find { |a| a.include?('JAMES SMTP Server') }
         return if match.zero?
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/apachejames.rb
+++ b/lib/sisimai/bite/email/apachejames.rb
@@ -18,7 +18,6 @@ module Sisimai::Bite::Email
         :begin  => %r/\AContent-Disposition:[ ]inline/,
         :error  => %r/\AError message below:\z/,
         :rfc822 => %r|\AContent-Type: message/rfc822|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/bigfoot.rb
+++ b/lib/sisimai/bite/email/bigfoot.rb
@@ -14,7 +14,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin  => %r/\A[ \t]+[-]+[ \t]*Transcript of session follows/,
         :rfc822 => %r|\AContent-Type: message/partial|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/bigfoot.rb
+++ b/lib/sisimai/bite/email/bigfoot.rb
@@ -6,11 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Bigfoot.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from     => %r/[@]bigfoot[.]com[>]/,
-        :subject  => %r/\AReturned mail: /,
-        :received => %r/\w+[.]bigfoot[.]com\b/,
-      }.freeze
       Re1 = {
         :begin  => %r/\A[ \t]+[-]+[ \t]*Transcript of session follows/,
         :rfc822 => %r|\AContent-Type: message/partial|,
@@ -35,10 +30,11 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-
+        
+        # :subject  => %r/\AReturned mail: /,
         match  = 0
-        match += 1 if mhead['from'] =~ Re0[:from]
-        match += 1 if mhead['received'].find { |a| a =~ Re0[:received] }
+        match += 1 if mhead['from'].include?('@bigfoot.com>')
+        match += 1 if mhead['received'].find { |a| a =~ /\w+[.]bigfoot[.]com\b/ }
         return nil if match.zero?
 
         require 'sisimai/address'

--- a/lib/sisimai/bite/email/biglobe.rb
+++ b/lib/sisimai/bite/email/biglobe.rb
@@ -14,7 +14,6 @@ module Sisimai::Bite::Email
         :begin  => %r/\A   ----- The following addresses had delivery problems -----\z/,
         :error  => %r/\A   ----- Non-delivered information -----\z/,
         :rfc822 => %r|\AContent-Type: message/rfc822\z|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         filtered:    %r/Mail Delivery Failed[.]+ User unknown/,

--- a/lib/sisimai/bite/email/biglobe.rb
+++ b/lib/sisimai/bite/email/biglobe.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Biglobe.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :subject => %r/\AReturned mail:/,
-        :from    => %r/postmaster[@](?:biglobe|inacatv|tmtv|ttv)[.]ne[.]jp/,
-      }.freeze
       Re1 = {
         :begin  => %r/\A   ----- The following addresses had delivery problems -----\z/,
         :error  => %r/\A   ----- Non-delivered information -----\z/,
@@ -39,8 +35,8 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['from']    =~ Re0[:from]
-        return nil unless mhead['subject'] =~ Re0[:subject]
+        return nil unless mhead['from'] =~ /postmaster[@](?:biglobe|inacatv|tmtv|ttv)[.]ne[.]jp/
+        return nil unless mhead['subject'].start_with?('Returned mail:')
 
         require 'sisimai/address'
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/courier.rb
+++ b/lib/sisimai/bite/email/courier.rb
@@ -28,7 +28,6 @@ module Sisimai::Bite::Email
           |text/rfc822-headers
           )\z
         }x,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         # courier/module.esmtp/esmtpclient.c:526| hard_error(del, ctf, "No such domain.");

--- a/lib/sisimai/bite/email/courier.rb
+++ b/lib/sisimai/bite/email/courier.rb
@@ -8,15 +8,6 @@ module Sisimai::Bite::Email
 
       # http://www.courier-mta.org/courierdsn.html
       # courier/module.dsn/dsn*.txt
-      Re0 = {
-        :'from'       => %r/Courier mail server at /,
-        :'subject'    => %r{(?:
-           NOTICE:[ ]mail[ ]delivery[ ]status[.]
-          |WARNING:[ ]delayed[ ]mail[.]
-          )
-        }x,
-        :'message-id' => %r/\A[<]courier[.][0-9A-F]+[.]/,
-      }.freeze
       Re1 = {
         :begin  => %r{(?:
            DELAYS[ ]IN[ ]DELIVERING[ ]YOUR[ ]MESSAGE
@@ -62,11 +53,11 @@ module Sisimai::Bite::Email
         return nil unless mbody
 
         match  = 0
-        match += 1 if mhead['from']    =~ Re0[:from]
-        match += 1 if mhead['subject'] =~ Re0[:subject]
+        match += 1 if mhead['from'] =~ /Courier mail server at /
+        match += 1 if mhead['subject'] =~ /(?:NOTICE: mail delivery status[.]|WARNING: delayed mail[.])/
         if mhead['message-id']
           # Message-ID: <courier.4D025E3A.00001792@5jo.example.org>
-          match += 1 if mhead['message-id'] =~ Re0[:'message-id']
+          match += 1 if mhead['message-id'] =~ /\A[<]courier[.][0-9A-F]+[.]/
         end
         return nil if match.zero?
 

--- a/lib/sisimai/bite/email/domino.rb
+++ b/lib/sisimai/bite/email/domino.rb
@@ -12,7 +12,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin   => %r/\AYour message/,
         :rfc822  => %r|\AContent-Type: message/delivery-status\z|,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         userunknown: %r{(?>

--- a/lib/sisimai/bite/email/domino.rb
+++ b/lib/sisimai/bite/email/domino.rb
@@ -6,9 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Domino.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :subject => %r/\ADELIVERY FAILURE:/,
-      }.freeze
       Re1 = {
         :begin   => %r/\AYour message/,
         :rfc822  => %r|\AContent-Type: message/delivery-status\z|,
@@ -45,7 +42,7 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['subject'] =~ Re0[:subject]
+        return nil unless mhead['subject'].start_with?('DELIVERY FAILURE:')
 
         require 'sisimai/address'
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/einsundeins.rb
+++ b/lib/sisimai/bite/email/einsundeins.rb
@@ -14,7 +14,6 @@ module Sisimai::Bite::Email
         :begin   => %r/\AThis message was created automatically by mail delivery software/,
         :error   => %r/\AFor the following reason:/,
         :rfc822  => %r/\A--- The header of the original message is following/,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         mesgtoobig: %r/Mail[ ]size[ ]limit[ ]exceeded/x,

--- a/lib/sisimai/bite/email/einsundeins.rb
+++ b/lib/sisimai/bite/email/einsundeins.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/EinsUndEins.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from    => %r/\A["]Mail Delivery System["]/,
-        :subject => %r/\AMail delivery failed: returning message to sender\z/,
-      }.freeze
       Re1 = {
         :begin   => %r/\AThis message was created automatically by mail delivery software/,
         :error   => %r/\AFor the following reason:/,
@@ -39,8 +35,8 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['from']    =~ Re0[:from]
-        return nil unless mhead['subject'] =~ Re0[:subject]
+        return nil unless mhead['from'].start_with?('"Mail Delivery System"')
+        return nil unless mhead['subject'].start_with?('Mail delivery failed: returning message to sender')
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/exchange2003.rb
+++ b/lib/sisimai/bite/email/exchange2003.rb
@@ -23,7 +23,6 @@ module Sisimai::Bite::Email
         :begin  => %r/\AYour message/,
         :error  => %r/\Adid not reach the following recipient[(]s[)]:/,
         :rfc822 => %r|\AContent-Type: message/rfc822|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       CodeTable = {
         onhold: [

--- a/lib/sisimai/bite/email/exchange2007.rb
+++ b/lib/sisimai/bite/email/exchange2007.rb
@@ -16,7 +16,6 @@ module Sisimai::Bite::Email
         :error  => %r/[ ]((?:RESOLVER|QUEUE)[.][A-Za-z]+(?:[.]\w+)?);/,
         :rhost  => %r/\AGenerating[ ]server:[ ]?(.*)/,
         :rfc822 => %r/\AOriginal message headers:/,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       NDRSubject = {
         :'SMTPSEND.DNS.NonExistentDomain'=> 'hostunknown',   # 554 5.4.4 SMTPSEND.DNS.NonExistentDomain

--- a/lib/sisimai/bite/email/exchange2007.rb
+++ b/lib/sisimai/bite/email/exchange2007.rb
@@ -7,10 +7,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Exchange2007.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'subject'          => %r/\AUndeliverable:/,
-        :'content-language' => %r/\A[a-z]{2}(?:[-][A-Z]{2})?\z/,
-      }.freeze
       Re1 = {
         :begin  => %r/[ ]Microsoft[ ]Exchange[ ]Server[ ]20\d{2}/,
         :error  => %r/[ ]((?:RESOLVER|QUEUE)[.][A-Za-z]+(?:[.]\w+)?);/,
@@ -52,9 +48,9 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
 
-        return nil unless mhead['subject'] =~ Re0[:'subject']
+        return nil unless mhead['subject'].start_with?('Undeliverable:')
         return nil unless mhead['content-language']
-        return nil unless mhead['content-language'] =~ Re0[:'content-language']
+        return nil unless mhead['content-language'] =~ /\A[a-z]{2}(?:[-][A-Z]{2})?\z/
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/exim.rb
+++ b/lib/sisimai/bite/email/exim.rb
@@ -6,24 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Exim.pm
       require 'sisimai/bite/email'
 
-      ReE = {
-        :from    => %r/[@].+[.]mail[.]ru[>]?/,
-      }.freeze
-      Re0 = {
-        :from    => %r/\AMail Delivery System/,
-        :subject => %r{(?:
-           Mail[ ]delivery[ ]failed(:[ ]returning[ ]message[ ]to[ ]sender)?
-          |Warning:[ ]message[ ].+[ ]delayed[ ]+
-          |Delivery[ ]Status[ ]Notification
-          |Mail[ ]failure
-          |Message[ ]frozen
-          |error[(]s[)][ ]in[ ]forwarding[ ]or[ ]filtering
-          )
-        }x,
-        # :'message-id' => %r/\A[<]\w+[-]\w+[-]\w+[@].+\z/,
-        # Message-Id: <E1P1YNN-0003AD-Ga@example.org>
-      }.freeze
-
       # Error text regular expressions which defined in exim/src/deliver.c
       #
       # deliver.c:6292| fprintf(f,
@@ -163,9 +145,19 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil if     mhead['from']    =~ ReE[:from]
-        return nil unless mhead['from']    =~ Re0[:from]
-        return nil unless mhead['subject'] =~ Re0[:subject]
+
+        # :'message-id' => %r/\A[<]\w+[-]\w+[-]\w+[@].+\z/,
+        return nil if     mhead['from'] =~ /[@].+[.]mail[.]ru[>]?/
+        return nil unless mhead['from'].start_with?('Mail Delivery System')
+        return nil unless mhead['subject'] =~ %r{(?:
+           Mail[ ]delivery[ ]failed(:[ ]returning[ ]message[ ]to[ ]sender)?
+          |Warning:[ ]message[ ].+[ ]delayed[ ]+
+          |Delivery[ ]Status[ ]Notification
+          |Mail[ ]failure
+          |Message[ ]frozen
+          |error[(]s[)][ ]in[ ]forwarding[ ]or[ ]filtering
+          )
+        }x
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/ezweb.rb
+++ b/lib/sisimai/bite/email/ezweb.rb
@@ -22,7 +22,6 @@ module Sisimai::Bite::Email
         }x,
         :rfc822   => %r#\A(?:[-]{50}|Content-Type:[ ]*message/rfc822)#,
         :boundary => %r/\A__SISIMAI_PSEUDO_BOUNDARY__\z/,
-        :endof    => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         # notaccept: [ %r/The following recipients did not receive this message:/ ],

--- a/lib/sisimai/bite/email/ezweb.rb
+++ b/lib/sisimai/bite/email/ezweb.rb
@@ -6,12 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/EZweb.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'from'       => %r/[<]?(?>postmaster[@]ezweb[.]ne[.]jp)[>]?/i,
-        :'subject'    => %r/\AMail System Error - Returned Mail\z/,
-        :'received'   => %r/\Afrom[ ](?:.+[.])?ezweb[.]ne[.]jp[ ]/,
-        :'message-id' => %r/[@].+[.]ezweb[.]ne[.]jp[>]\z/,
-      }.freeze
       Re1 = {
         :begin  => %r{\A(?:
              The[ ]user[(]s[)][ ]
@@ -65,11 +59,11 @@ module Sisimai::Bite::Email
         return nil unless mbody
 
         match  = 0
-        match += 1 if mhead['from']    =~ Re0[:from]
-        match += 1 if mhead['subject'] =~ Re0[:subject]
-        match += 1 if mhead['received'].find { |a| a =~ Re0[:received] }
+        match += 1 if mhead['from'] =~ /[<]?(?>postmaster[@]ezweb[.]ne[.]jp)[>]?/i
+        match += 1 if mhead['subject'].start_with?('Mail System Error - Returned Mail')
+        match += 1 if mhead['received'].find { |a| a =~ /\Afrom[ ](?:.+[.])?ezweb[.]ne[.]jp[ ]/ }
         if mhead['message-id']
-          match += 1 if mhead['message-id'] =~ Re0[:'message-id']
+          match += 1 if mhead['message-id'] =~ /[@].+[.]ezweb[.]ne[.]jp[>]\z/
         end
         return nil if match < 2
 

--- a/lib/sisimai/bite/email/facebook.rb
+++ b/lib/sisimai/bite/email/facebook.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Facebook.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from    => %r/\AFacebook [<]mailer-daemon[@]mx[.]facebook[.]com[>]\z/,
-        :subject => %r/\ASorry, your message could not be delivered\z/,
-      }.freeze
       Re1 = {
         :begin   => %r/\AThis message was created automatically by Facebook[.]\z/,
         :rfc822  => %r/\AContent-Disposition: inline\z/,
@@ -94,8 +90,8 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['from']    =~ Re0[:from]
-        return nil unless mhead['subject'] =~ Re0[:subject]
+        return nil unless mhead['from'].start_with?('Facebook <mailer-daemon@mx.facebook.com>')
+        return nil unless mhead['subject'].start_with?('Sorry, your message could not be delivered')
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/facebook.rb
+++ b/lib/sisimai/bite/email/facebook.rb
@@ -13,7 +13,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin   => %r/\AThis message was created automatically by Facebook[.]\z/,
         :rfc822  => %r/\AContent-Disposition: inline\z/,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
 
       # http://postmaster.facebook.com/response_codes

--- a/lib/sisimai/bite/email/fml.rb
+++ b/lib/sisimai/bite/email/fml.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/FML.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'from'       => %r/.+[-]admin[@].+/, 
-        :'message-id' => %r/\A[<]\d+[.]FML.+[@].+[>]\z/,
-      }.freeze
       Re1 = {
         :rfc822  => %r/\AOriginal[ ]mail[ ]as[ ]follows:\z/,
       }.freeze
@@ -70,8 +66,8 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
         return nil unless mhead['x-mlserver']
-        return nil unless mhead['from'] =~ Re0[:from]
-        return nil unless mhead['message-id'] =~ Re0[:'message-id']
+        return nil unless mhead['from'] =~ /.+[-]admin[@].+/
+        return nil unless mhead['message-id'] =~ /\A[<]\d+[.]FML.+[@].+[>]\z/
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/fml.rb
+++ b/lib/sisimai/bite/email/fml.rb
@@ -12,7 +12,6 @@ module Sisimai::Bite::Email
       }.freeze
       Re1 = {
         :rfc822  => %r/\AOriginal[ ]mail[ ]as[ ]follows:\z/,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ErrorTitle = {
         :rejected => %r{(?>

--- a/lib/sisimai/bite/email/gmx.rb
+++ b/lib/sisimai/bite/email/gmx.rb
@@ -13,7 +13,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin   => %r/\AThis message was created automatically by mail delivery software/,
         :rfc822  => %r/\A--- The header of the original message is following/,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         expired: %r/delivery[ ]retry[ ]timeout[ ]exceeded/x,

--- a/lib/sisimai/bite/email/gmx.rb
+++ b/lib/sisimai/bite/email/gmx.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/GMX.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from    => %r/\AMAILER-DAEMON[@]/,
-        :subject => %r/\AMail delivery failed: returning message to sender\z/,
-      }.freeze
       Re1 = {
         :begin   => %r/\AThis message was created automatically by mail delivery software/,
         :rfc822  => %r/\A--- The header of the original message is following/,
@@ -42,6 +38,9 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
+
+        # :from    => %r/\AMAILER-DAEMON[@]/,
+        # :subject => %r/\AMail delivery failed: returning message to sender\z/,
         return nil unless mhead['x-gmx-antispam']
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/google.rb
+++ b/lib/sisimai/bite/email/google.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Google.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from    => %r/[@]googlemail[.]com[>]?\z/,
-        :subject => %r/Delivery[ ]Status[ ]Notification/,
-      }.freeze
       Re1 = {
         :begin   => %r/Delivery to the following recipient/,
         :start   => %r/Technical details of (?:permanent|temporary) failure:/,
@@ -174,8 +170,8 @@ module Sisimai::Bite::Email
         #   The error that the other server returned was:
         #   550 5.1.1 <userunknown@example.jp>... User Unknown
         #
-        return nil unless mhead['from']    =~ Re0[:from]
-        return nil unless mhead['subject'] =~ Re0[:subject]
+        return nil unless mhead['from'].include?('<mailer-daemon@googlemail.com>')
+        return nil unless mhead['subject'].include?('Delivery Status Notification')
 
         require 'sisimai/address'
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/google.rb
+++ b/lib/sisimai/bite/email/google.rb
@@ -19,7 +19,6 @@ module Sisimai::Bite::Email
             |[ \t]*-----[ ]Message[ ]header[ ]follows[ ]-----
             )\z
         }x,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         expired: %r{(?:

--- a/lib/sisimai/bite/email/gsuite.rb
+++ b/lib/sisimai/bite/email/gsuite.rb
@@ -15,7 +15,6 @@ module Sisimai::Bite::Email
         :error   => %r/\AThe[ ]response([ ]from[ ]the[ ]remote[ ]server)?[ ]was:\z/,
         :html    => %r{\AContent-Type:[ ]*text/html;[ ]*charset=['"]?(?:UTF|utf)[-]8['"]?\z},
         :rfc822  => %r{\AContent-Type:[ ]*(?:message/rfc822|text/rfc822-headers)\z},
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ErrorMayBe = {
         :userunknown  => %r/because the address couldn't be found/,

--- a/lib/sisimai/bite/email/gsuite.rb
+++ b/lib/sisimai/bite/email/gsuite.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/GSuite.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from    => %r/[@]googlemail[.]com[>]?\z/,
-        :subject => %r/Delivery[ ]Status[ ]Notification/,
-      }.freeze
       Re1 = {
         :begin   => %r/\A[*][*][ ].+[ ][*][*]\z/,
         :error   => %r/\AThe[ ]response([ ]from[ ]the[ ]remote[ ]server)?[ ]was:\z/,
@@ -42,8 +38,8 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
 
-        return nil unless mhead['from']    =~ Re0[:from]
-        return nil unless mhead['subject'] =~ Re0[:subject]
+        return nil unless mhead['from'].include?('<mailer-daemon@googlemail.com>')
+        return nil unless mhead['subject'].include?('Delivery Status Notification')
         return nil unless mhead['x-gm-message-state']
 
         require 'sisimai/address'

--- a/lib/sisimai/bite/email/imailserver.rb
+++ b/lib/sisimai/bite/email/imailserver.rb
@@ -7,10 +7,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite::Email/IMailServer.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'x-mailer' => %r/\A[<]SMTP32 v[\d.]+[>][ ]*\z/,
-        :'subject'  => %r/\AUndeliverable Mail[ ]*\z/,
-      }.freeze
       Re1 = {
         :begin  => %r/\A\z/,    # Blank line
         :error  => %r/Body of message generated response:/,
@@ -57,8 +53,8 @@ module Sisimai::Bite::Email
         return nil unless mbody
 
         match  = 0
-        match += 1 if mhead['subject'] =~ Re0[:subject]
-        match += 1 if mhead['x-mailer'] && mhead['x-mailer'] =~ Re0[:'x-mailer']
+        match += 1 if mhead['subject'] =~ /\AUndeliverable Mail[ ]*\z/
+        match += 1 if mhead['x-mailer'] && mhead['x-mailer'] =~ /\A[<]SMTP32 v[\d.]+[>][ ]*\z/
         return nil if match.zero?
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/imailserver.rb
+++ b/lib/sisimai/bite/email/imailserver.rb
@@ -15,7 +15,6 @@ module Sisimai::Bite::Email
         :begin  => %r/\A\z/,    # Blank line
         :error  => %r/Body of message generated response:/,
         :rfc822 => %r/\AOriginal message follows[.]\z/,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReSMTP = {
         conn: %r{(?:

--- a/lib/sisimai/bite/email/interscanmss.rb
+++ b/lib/sisimai/bite/email/interscanmss.rb
@@ -21,7 +21,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin  => %r|\AContent-type: text/plain|,
         :rfc822 => %r|\AContent-type: message/rfc822|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/interscanmss.rb
+++ b/lib/sisimai/bite/email/interscanmss.rb
@@ -7,17 +7,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/InterScanMSS.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from     => %r/InterScan MSS/,
-        :received => %r/[ ][(]InterScanMSS[)][ ]with[ ]/,
-        :subject  => [
-          'Mail could not be delivered',
-          # メッセージを配信できません。
-          '=?iso-2022-jp?B?GyRCJWElQyU7ITwlOCRyR1s/LiRHJC0kXiQ7JHMhIxsoQg==?=',
-          # メール配信に失敗しました
-          '=?iso-2022-jp?B?GyRCJWEhPCVrR1s/LiRLPDpHVCQ3JF4kNyQ/GyhCDQo=?=',
-        ],
-      }.freeze
       Re1 = {
         :begin  => %r|\AContent-type: text/plain|,
         :rfc822 => %r|\AContent-type: message/rfc822|,
@@ -43,9 +32,17 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
 
-        match  = 0
-        match += 1 if mhead['from'] =~ Re0[:from]
-        match += 1 if Re0[:subject].find { |a| mhead['subject'] == a }
+        # :received => %r/[ ][(]InterScanMSS[)][ ]with[ ]/,
+        match = 0
+        tryto = [
+          'Mail could not be delivered',
+          # メッセージを配信できません。
+          '=?iso-2022-jp?B?GyRCJWElQyU7ITwlOCRyR1s/LiRHJC0kXiQ7JHMhIxsoQg==?=',
+          # メール配信に失敗しました
+          '=?iso-2022-jp?B?GyRCJWEhPCVrR1s/LiRLPDpHVCQ3JF4kNyQ/GyhCDQo=?=',
+        ]
+        match += 1 if mhead['from'].include?('InterScan MSS')
+        match += 1 if tryto.find { |a| mhead['subject'].include?(a) }
         return nil if match.zero?
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/kddi.rb
+++ b/lib/sisimai/bite/email/kddi.rb
@@ -20,7 +20,6 @@ module Sisimai::Bite::Email
         /x,
         :rfc822 => %r|\AContent-Type: message/rfc822\z|,
         :error  => %r/Could not be delivered to:? /,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         mailboxfull: %r/As[ ]their[ ]mailbox[ ]is[ ]full/x,

--- a/lib/sisimai/bite/email/kddi.rb
+++ b/lib/sisimai/bite/email/kddi.rb
@@ -6,12 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/KDDI.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'from'       => %r/no-reply[@].+[.]dion[.]ne[.]jp/,
-        :'reply-to'   => %r/\Afrom[ \t]+\w+[.]auone[-]net[.]jp[ \t]/,
-        :'received'   => %r/\Afrom[ ](?:.+[.])?ezweb[.]ne[.]jp[ ]/,
-        :'message-id' => %r/[@].+[.]ezweb[.]ne[.]jp[>]\z/,
-      }.freeze
       Re1 = {
         :begin => %r/\AYour[ ]mail[ ](?:
              sent[ ]on:?[ ][A-Z][a-z]{2}[,]
@@ -47,10 +41,11 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
 
+        # :'message-id' => %r/[@].+[.]ezweb[.]ne[.]jp[>]\z/,
         match  = 0
-        match += 1 if mhead['from']    =~ Re0[:from]
-        match += 1 if mhead['reply-to'] && mhead['reply-to'] =~ Re0[:'reply-to']
-        match += 1 if mhead['received'].find { |a| a =~ Re0[:received] }
+        match += 1 if mhead['from'] =~ /no-reply[@].+[.]dion[.]ne[.]jp/
+        match += 1 if mhead['reply-to'] && mhead['reply-to'] =~ /\Afrom[ \t]+\w+[.]auone[-]net[.]jp[ \t]/
+        match += 1 if mhead['received'].find { |a| a =~ /\Afrom[ ](?:.+[.])?ezweb[.]ne[.]jp[ ]/ }
         return nil if match.zero?
 
         require 'sisimai/string'

--- a/lib/sisimai/bite/email/mailfoundry.rb
+++ b/lib/sisimai/bite/email/mailfoundry.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/MailFoundry.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :subject  => %r/\AMessage delivery has failed\z/,
-        :received => %r/[(]MAILFOUNDRY[)] id /,
-      }.freeze
       Re1 = {
         :begin  => %r/\AThis is a MIME encoded message\z/,
         :error  => %r/\ADelivery failed for the following reason:\z/,
@@ -35,8 +31,8 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['subject'] =~ Re0[:subject]
-        return nil unless mhead['received'].find { |a| a =~ Re0[:received] }
+        return nil unless mhead['subject'].start_with?('Message delivery has failed')
+        return nil unless mhead['received'].find { |a| a.include?('(MAILFOUNDRY) id ') }
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/mailfoundry.rb
+++ b/lib/sisimai/bite/email/mailfoundry.rb
@@ -14,7 +14,6 @@ module Sisimai::Bite::Email
         :begin  => %r/\AThis is a MIME encoded message\z/,
         :error  => %r/\ADelivery failed for the following reason:\z/,
         :rfc822 => %r|\AContent-Type: message/rfc822\z|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/mailmarshalsmtp.rb
+++ b/lib/sisimai/bite/email/mailmarshalsmtp.rb
@@ -15,7 +15,6 @@ module Sisimai::Bite::Email
         :rfc822 => nil,
         :error  => %r/\ACould not be delivered because of\z/,
         :rcpts  => %r/\AThe following recipients were affected:/,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/mailmarshalsmtp.rb
+++ b/lib/sisimai/bite/email/mailmarshalsmtp.rb
@@ -7,9 +7,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/MailMarshalSMTP.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :subject  => %r/\AUndeliverable Mail: ["]/,
-      }.freeze
       Re1 = {
         :begin  => %r/\AYour message:\z/,
         :rfc822 => nil,
@@ -36,7 +33,7 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['subject'] =~ Re0[:subject]
+        return nil unless mhead['subject'].start_with?('Undeliverable Mail: "')
 
         require 'sisimai/mime'
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/mailru.rb
+++ b/lib/sisimai/bite/email/mailru.rb
@@ -7,20 +7,6 @@ module Sisimai::Bite::Email
       # Based on Sisimai::Bite::Email::Exim
       require 'sisimai/bite/email'
 
-      Re0 = {
-        # Message-Id: <E1P1YNN-0003AD-Ga@*.mail.ru>
-        :'message-id' => %r/\A[<]\w+[-]\w+[-]\w+[@].*mail[.]ru[>]\z/,
-        :'from'       => %r/[<]?mailer-daemon[@].*mail[.]ru[>]?/i,
-        :'subject'    => %r{(?:
-           Mail[ ]delivery[ ]failed(:[ ]returning[ ]message[ ]to[ ]sender)?
-          |Warning:[ ]message[ ].+[ ]delayed[ ]+
-          |Delivery[ ]Status[ ]Notification
-          |Mail[ ]failure
-          |Message[ ]frozen
-          |error[(]s[)][ ]in[ ]forwarding[ ]or[ ]filtering
-          )
-        }x,
-      }.freeze
       Re1 = {
         :rfc822 => %r/\A------ This is a copy of the message.+headers[.] ------\z/,
         :begin  => %r/\AThis message was created automatically by mail delivery software[.]/,
@@ -77,9 +63,18 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['from']       =~ Re0[:from]
-        return nil unless mhead['subject']    =~ Re0[:subject]
-        return nil unless mhead['message-id'] =~ Re0[:'message-id']
+
+        return nil unless mhead['from'] =~ /[<]?mailer-daemon[@].*mail[.]ru[>]?/i
+        return nil unless mhead['message-id'] =~ /\A[<]\w+[-]\w+[-]\w+[@].*mail[.]ru[>]\z/
+        return nil unless mhead['subject'] =~ %r{(?:
+           Mail[ ]delivery[ ]failed(:[ ]returning[ ]message[ ]to[ ]sender)?
+          |Warning:[ ]message[ ].+[ ]delayed[ ]+
+          |Delivery[ ]Status[ ]Notification
+          |Mail[ ]failure
+          |Message[ ]frozen
+          |error[(]s[)][ ]in[ ]forwarding[ ]or[ ]filtering
+          )
+        }x
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/mailru.rb
+++ b/lib/sisimai/bite/email/mailru.rb
@@ -24,7 +24,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :rfc822 => %r/\A------ This is a copy of the message.+headers[.] ------\z/,
         :begin  => %r/\AThis message was created automatically by mail delivery software[.]/,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReCommand = [
         %r/SMTP error from remote (?:mail server|mailer) after ([A-Za-z]{4})/,

--- a/lib/sisimai/bite/email/mcafee.rb
+++ b/lib/sisimai/bite/email/mcafee.rb
@@ -14,7 +14,6 @@ module Sisimai::Bite::Email
         :begin   => %r/[-]+ The following addresses had delivery problems [-]+\z/,
         :error   => %r|\AContent-Type: [^ ]+/[^ ]+; name="deliveryproblems[.]txt"|,
         :rfc822  => %r|\AContent-Type: message/rfc822\z|,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         userunknown: %r{(?:

--- a/lib/sisimai/bite/email/mcafee.rb
+++ b/lib/sisimai/bite/email/mcafee.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/McAfee.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'x-nai'   => %r/Modified by McAfee /,
-        :'subject' => %r/\ADelivery Status\z/,
-      }.freeze
       Re1 = {
         :begin   => %r/[-]+ The following addresses had delivery problems [-]+\z/,
         :error   => %r|\AContent-Type: [^ ]+/[^ ]+; name="deliveryproblems[.]txt"|,
@@ -43,8 +39,8 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
         return nil unless mhead['x-nai-header']
-        return nil unless mhead['x-nai-header'] =~ Re0[:'x-nai']
-        return nil unless mhead['subject']      =~ Re0[:'subject']
+        return nil unless mhead['x-nai-header'].include?('Modified by McAfee ')
+        return nil unless mhead['subject'].start_with?('Delivery Status')
 
         require 'sisimai/address'
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/messagelabs.rb
+++ b/lib/sisimai/bite/email/messagelabs.rb
@@ -15,7 +15,6 @@ module Sisimai::Bite::Email
         :begin   => %r|\AContent-Type: message/delivery-status|,
         :error   => %r/\AReason:[ \t]*(.+)\z/,
         :rfc822  => %r|\AContent-Type: text/rfc822-headers\z|,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         userunknown: %r{(?:

--- a/lib/sisimai/bite/email/messagelabs.rb
+++ b/lib/sisimai/bite/email/messagelabs.rb
@@ -7,10 +7,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/MessageLabs.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from    => %r/MAILER-DAEMON[@]messagelabs[.]com/,
-        :subject => %r/\AMail Delivery Failure/,
-      }.freeze
       Re1 = {
         :begin   => %r|\AContent-Type: message/delivery-status|,
         :error   => %r/\AReason:[ \t]*(.+)\z/,
@@ -51,8 +47,8 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
         return nil unless mhead['x-msg-ref']
-        return nil unless mhead['from']    =~ Re0[:from]
-        return nil unless mhead['subject'] =~ Re0[:subject]
+        return nil unless mhead['from'].include?('MAILER-DAEMON@messagelabs.com')
+        return nil unless mhead['subject'].start_with?('Mail Delivery Failure')
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/messagingserver.rb
+++ b/lib/sisimai/bite/email/messagingserver.rb
@@ -8,11 +8,6 @@ module Sisimai::Bite::Email
       require 'sisimai/bite'
       require 'sisimai/rfc5322'
 
-      Re0 = {
-        :subject  => %r/\ADelivery Notification: /,
-        :received => %r/[ ][(]MessagingServer[)][ ]with[ ]/,
-        :boundary => %r/Boundary_[(]ID_.+[)]/,
-      }.freeze
       Re1 = {
         :begin  => %r/\AThis report relates to a message you sent with the following header fields:/,
         :rfc822 => %r!\A(?:Content-type:[ ]*message/rfc822|Return-path:[ ]*)!x,
@@ -41,9 +36,10 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
 
+        # :received => %r/[ ][(]MessagingServer[)][ ]with[ ]/,
         match  = 0
-        match += 1 if mhead['content-type'] =~ Re0[:boundary]
-        match += 1 if mhead['subject']      =~ Re0[:subject]
+        match += 1 if mhead['content-type'] =~ /Boundary_[(]ID_.+[)]/
+        match += 1 if mhead['subject'].start_with?('Delivery Notification: ')
         return nil if match.zero?
 
         require 'sisimai/address'

--- a/lib/sisimai/bite/email/messagingserver.rb
+++ b/lib/sisimai/bite/email/messagingserver.rb
@@ -15,7 +15,6 @@ module Sisimai::Bite::Email
       }.freeze
       Re1 = {
         :begin  => %r/\AThis report relates to a message you sent with the following header fields:/,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
         :rfc822 => %r!\A(?:Content-type:[ ]*message/rfc822|Return-path:[ ]*)!x,
       }.freeze
       ReFailure = {

--- a/lib/sisimai/bite/email/mfilter.rb
+++ b/lib/sisimai/bite/email/mfilter.rb
@@ -17,7 +17,6 @@ module Sisimai::Bite::Email
         :error   => %r/\A-------server message\z/,
         :command => %r/\A-------SMTP command\z/,
         :rfc822  => %r/\A-------original (?:message|mail info)\z/,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/mfilter.rb
+++ b/lib/sisimai/bite/email/mfilter.rb
@@ -7,11 +7,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/mFILTER.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'from'     => %r/\AMailer Daemon [<]MAILER-DAEMON[@]/,
-        :'subject'  => %r/\Afailure notice\z/,
-        :'x-mailer' => %r/\Am-FILTER\z/,
-      }.freeze
       Re1 = {
         :begin   => %r/\A[^ ]+[@][^ ]+[.][a-zA-Z]+\z/,
         :error   => %r/\A-------server message\z/,
@@ -38,9 +33,11 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
+
+        # :'from'     => %r/\AMailer Daemon [<]MAILER-DAEMON[@]/,
         return nil unless mhead['x-mailer']
-        return nil unless mhead['x-mailer'] =~ Re0[:'x-mailer']
-        return nil unless mhead['subject']  =~ Re0[:'subject']
+        return nil unless mhead['x-mailer'].start_with?('m-FILTER')
+        return nil unless mhead['subject'].start_with?('failure notice')
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/mxlogic.rb
+++ b/lib/sisimai/bite/email/mxlogic.rb
@@ -21,7 +21,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :rfc822 => %r/\AIncluded is a copy of the message header:\z/,
         :begin  => %r/\AThis message was created automatically by mail delivery software[.]\z/,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReCommand = [
         %r/SMTP error from remote (?:mail server|mailer) after ([A-Za-z]{4})/,

--- a/lib/sisimai/bite/email/mxlogic.rb
+++ b/lib/sisimai/bite/email/mxlogic.rb
@@ -8,16 +8,6 @@ module Sisimai::Bite::Email
       # Based on Sisimai::Bite::Email::Exim
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'from'      => %r/\AMail Delivery System/,
-        :'subject'   => %r{(?:
-             Mail[ ]delivery[ ]failed(:[ ]returning[ ]message[ ]to[ ]sender)?
-            |Warning:[ ]message[ ].+[ ]delayed[ ]+
-            |Delivery[ ]Status[ ]Notification
-            )
-        }x,
-        :'message-id' => %r/\A[<]mxl[~][0-9a-f]+/,
-      }.freeze
       Re1 = {
         :rfc822 => %r/\AIncluded is a copy of the message header:\z/,
         :begin  => %r/\AThis message was created automatically by mail delivery software[.]\z/,
@@ -91,12 +81,18 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
 
+        # :'message-id' => %r/\A[<]mxl[~][0-9a-f]+/,
         match  = 0
         match += 1 if mhead['x-mx-bounce']
         match += 1 if mhead['x-mxl-hash']
         match += 1 if mhead['x-mxl-notehash']
-        match += 1 if mhead['subject'] =~ Re0[:subject]
-        match += 1 if mhead['from']    =~ Re0[:from]
+        match += 1 if mhead['from'].start_with?('Mail Delivery System')
+        match += 1 if mhead['subject'] =~ %r{(?:
+             Mail[ ]delivery[ ]failed(:[ ]returning[ ]message[ ]to[ ]sender)?
+            |Warning:[ ]message[ ].+[ ]delayed[ ]+
+            |Delivery[ ]Status[ ]Notification
+            )
+        }x
         return nil if match.zero?
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/notes.rb
+++ b/lib/sisimai/bite/email/notes.rb
@@ -12,7 +12,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin  => %r/\A[-]+[ ]+Failure Reasons[ ]+[-]+\z/,
         :rfc822 => %r/^[-]+[ ]+Returned Message[ ]+[-]+$/,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         userunknown: %r{(?:

--- a/lib/sisimai/bite/email/notes.rb
+++ b/lib/sisimai/bite/email/notes.rb
@@ -6,9 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Notes.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'subject' => %r/\AUndeliverable message/,
-      }.freeze
       Re1 = {
         :begin  => %r/\A[-]+[ ]+Failure Reasons[ ]+[-]+\z/,
         :rfc822 => %r/^[-]+[ ]+Returned Message[ ]+[-]+$/,
@@ -41,7 +38,7 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['subject'] =~ Re0[:subject]
+        return nil unless mhead['subject'].start_with?('Undeliverable message')
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/office365.rb
+++ b/lib/sisimai/bite/email/office365.rb
@@ -7,11 +7,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Office365.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'subject'    => %r/Undeliverable:/,
-        :'received'   => %r/.+[.](?:outbound[.]protection|prod)[.]outlook[.]com\b/,
-        :'message-id' => %r/.+[.](?:outbound[.]protection|prod)[.]outlook[.]com\b/,
-      }.freeze
       Re1 = {
         :begin  => %r{\A(?:
            Delivery[ ]has[ ]failed[ ]to[ ]these[ ]recipients[ ]or[ ]groups:
@@ -88,7 +83,7 @@ module Sisimai::Bite::Email
         return nil unless mbody
 
         match  = 0
-        match += 1 if mhead['subject'] =~ Re0[:subject]
+        match += 1 if mhead['subject'].include?('Undeliverable:')
         match += 1 if mhead['x-ms-exchange-message-is-ndr']
         match += 1 if mhead['x-microsoft-antispam-prvs']
         match += 1 if mhead['x-exchange-antispam-report-test']
@@ -96,10 +91,10 @@ module Sisimai::Bite::Email
         match += 1 if mhead['x-ms-exchange-crosstenant-originalarrivaltime']
         match += 1 if mhead['x-ms-exchange-crosstenant-fromentityheader']
         match += 1 if mhead['x-ms-exchange-transport-crosstenantheadersstamped']
-        match += 1 if mhead['received'].find { |a| a =~ Re0[:received] }
+        match += 1 if mhead['received'].find { |a| a =~ /.+[.](?:outbound[.]protection|prod)[.]outlook[.]com\b/ }
         if mhead['message-id']
           # Message-ID: <00000000-0000-0000-0000-000000000000@*.*.prod.outlook.com>
-          match += 1 if mhead['message-id'] =~ Re0[:'message-id']
+          match += 1 if mhead['message-id'] =~ /.+[.](?:outbound[.]protection|prod)[.]outlook[.]com\b/
         end
         return nil if match < 2
 

--- a/lib/sisimai/bite/email/office365.rb
+++ b/lib/sisimai/bite/email/office365.rb
@@ -21,7 +21,6 @@ module Sisimai::Bite::Email
         :error  => %r/\ADiagnostic information for administrators:\z/,
         :eoerr  => %r/\AOriginal message headers:\z/,
         :rfc822 => %r|\AContent-Type: message/rfc822\z|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       CodeTable = {
         # https://support.office.com/en-us/article/Email-non-delivery-reports-in-Office-365-51daa6b9-2e35-49c4-a0c9-df85bf8533c3

--- a/lib/sisimai/bite/email/opensmtpd.rb
+++ b/lib/sisimai/bite/email/opensmtpd.rb
@@ -39,7 +39,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin  => %r/\A[ \t]*This is the MAILER-DAEMON, please DO NOT REPLY to this e[-]?mail[.]\z/,
         :rfc822 => %r/\A[ \t]*Below is a copy of the original message:\z/,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         expired: %r{

--- a/lib/sisimai/bite/email/opensmtpd.rb
+++ b/lib/sisimai/bite/email/opensmtpd.rb
@@ -6,11 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/OpenSMTPD.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from     => %r/\AMailer Daemon [<][^ ]+[@]/,
-        :subject  => %r/\ADelivery status notification/,
-        :received => %r/[ ][(]OpenSMTPD[)][ ]with[ ]/,
-      }.freeze
       # http://www.openbsd.org/cgi-bin/man.cgi?query=smtpd&sektion=8
       # opensmtpd-5.4.2p1/smtpd/
       #   bounce.c/317:#define NOTICE_INTRO \
@@ -96,9 +91,10 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['subject'] =~ Re0[:subject]
-        return nil unless mhead['from']    =~ Re0[:from]
-        return nil unless mhead['received'].find { |a| a =~ Re0[:received] }
+
+        return nil unless mhead['subject'].start_with?('Delivery status notification')
+        return nil unless mhead['from'] =~ /\AMailer Daemon [<][^ ]+[@]/
+        return nil unless mhead['received'].find { |a| a.include?(' (OpenSMTPD) with ') }
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/outlook.rb
+++ b/lib/sisimai/bite/email/outlook.rb
@@ -7,11 +7,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/US/Outlook.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from     => %r/postmaster[@]/,
-        :subject  => %r/Delivery Status Notification/,
-        :received => %r/.+[.]hotmail[.]com\b/,
-      }.freeze
       Re1 = {
         :begin  => %r/\AThis is an automatically generated Delivery Status Notification/,
         :error  => %r/\A[.]+ while talking to .+[:]\z/,
@@ -45,11 +40,12 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
 
+        # :from => %r/postmaster[@]/,
         match  = 0
-        match += 1 if mhead['subject']    =~ Re0[:subject]
+        match += 1 if mhead['subject'].include?('Delivery Status Notification')
         match += 1 if mhead['x-message-delivery']
         match += 1 if mhead['x-message-info']
-        match += 1 if mhead['received'].find { |a| a =~ Re0[:received] }
+        match += 1 if mhead['received'].find { |a| a =~ /.+[.]hotmail[.]com\b/ }
         return nil if match < 2
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/outlook.rb
+++ b/lib/sisimai/bite/email/outlook.rb
@@ -16,7 +16,6 @@ module Sisimai::Bite::Email
         :begin  => %r/\AThis is an automatically generated Delivery Status Notification/,
         :error  => %r/\A[.]+ while talking to .+[:]\z/,
         :rfc822 => %r|\AContent-Type: message/rfc822\z|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         hostunknown: %r/The mail could not be delivered to the recipient because the domain is not reachable/,

--- a/lib/sisimai/bite/email/postfix.rb
+++ b/lib/sisimai/bite/email/postfix.rb
@@ -31,7 +31,6 @@ module Sisimai::Bite::Email
           )
         }x,
         :rfc822 => %r!\AContent-Type:[ \t]*(?:message/rfc822|text/rfc822-headers)\z!x,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/postfix.rb
+++ b/lib/sisimai/bite/email/postfix.rb
@@ -7,10 +7,6 @@ module Sisimai::Bite::Email
       require 'sisimai/bite/email'
 
       # Postfix manual - bounce(5) - http://www.postfix.org/bounce.5.html
-      Re0 = {
-        :from    => %r/ [(]Mail Delivery System[)]\z/,
-        :subject => %r/\AUndelivered Mail Returned to Sender\z/,
-      }.freeze
       Re1 = {
         :begin => %r{\A(?>
            [ ]+The[ ](?:
@@ -52,7 +48,9 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['subject'] =~ Re0[:subject]
+
+        # :from => %r/ [(]Mail Delivery System[)]\z/,
+        return nil unless mhead['subject'].start_with?('Undelivered Mail Returned to Sender')
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/qmail.rb
+++ b/lib/sisimai/bite/email/qmail.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/qmail.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :subject  => %r/\Afailure notice/i,
-        :received => %r/\A[(]qmail[ ]+\d+[ ]+invoked[ ]+(?:for[ ]+bounce|from[ ]+network)[)]/,
-      }.freeze
       #  qmail-remote.c:248|    if (code >= 500) {
       #  qmail-remote.c:249|      out("h"); outhost(); out(" does not like recipient.\n");
       #  qmail-remote.c:265|  if (code >= 500) quit("D"," failed on DATA command");
@@ -141,9 +137,10 @@ module Sisimai::Bite::Email
         # by qmail, see http://cr.yp.to/qmail.html
         #   e.g.) Received: (qmail 12345 invoked for bounce); 29 Apr 2009 12:34:56 -0000
         #         Subject: failure notice
+        tryto  = /\A[(]qmail[ ]+\d+[ ]+invoked[ ]+(?:for[ ]+bounce|from[ ]+network)[)]/
         match  = 0
-        match += 1 if mhead['subject'] =~ Re0[:subject]
-        match += 1 if mhead['received'].find { |a| a =~ Re0[:received] }
+        match += 1 if mhead['subject'].start_with?('failure notice')
+        match += 1 if mhead['received'].find { |a| a =~ tryto }
         return nil if match.zero?
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/qmail.rb
+++ b/lib/sisimai/bite/email/qmail.rb
@@ -22,7 +22,6 @@ module Sisimai::Bite::Email
         :rfc822 => %r/\A--- Below this line is a copy of the message[.]\z/,
         :error  => %r/\ARemote host said:/,
         :sorry  => %r/\A[Ss]orry[,.][ ]/,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReSMTP = {
         # Error text regular expressions which defined in qmail-remote.c

--- a/lib/sisimai/bite/email/receivingses.rb
+++ b/lib/sisimai/bite/email/receivingses.rb
@@ -8,10 +8,6 @@ module Sisimai::Bite::Email
       require 'sisimai/bite/email'
 
       # http://aws.amazon.com/ses/
-      Re0 = {
-        :subject  => %r/\ADelivery Status Notification [(]Failure[)]\z/,
-        :received => %r/.+[.]smtp-out[.].+[.]amazonses[.]com\b/,
-      }.freeze
       Re1 = {
         :begin  => %r/\AThis message could not be delivered[.]\z/,
         :rfc822 => %r|\Acontent-type: text/rfc822-headers\z|,
@@ -46,6 +42,9 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
+
+        # :subject  => %r/\ADelivery Status Notification [(]Failure[)]\z/,
+        # :received => %r/.+[.]smtp-out[.].+[.]amazonses[.]com\b/,
         return nil unless mhead['x-ses-outgoing']
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/receivingses.rb
+++ b/lib/sisimai/bite/email/receivingses.rb
@@ -15,7 +15,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin  => %r/\AThis message could not be delivered[.]\z/,
         :rfc822 => %r|\Acontent-type: text/rfc822-headers\z|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         # The followings are error messages in Rule sets/*/Actions/Template

--- a/lib/sisimai/bite/email/sendgrid.rb
+++ b/lib/sisimai/bite/email/sendgrid.rb
@@ -6,11 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/SendGrid.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'from'        => %r/\AMAILER-DAEMON\z/,
-        :'return-path' => %r/\A[<]apps[@]sendgrid[.]net[>]\z/,
-        :'subject'     => %r/\AUndelivered Mail Returned to Sender\z/,
-      }.freeze
       Re1 = {
         :begin  => %r/\AThis is an automatically generated message from SendGrid[.]\z/,
         :error  => %r/\AIf you require assistance with this, please contact SendGrid support[.]\z/,
@@ -39,9 +34,11 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
+
+        # :'from'        => %r/\AMAILER-DAEMON\z/,
         return nil unless mhead['return-path']
-        return nil unless mhead['return-path'] =~ Re0[:'return-path']
-        return nil unless mhead['subject']     =~ Re0[:'subject']
+        return nil unless mhead['return-path'].start_with?('<apps@sendgrid.net>')
+        return nil unless mhead['subject'].start_with?('Undelivered Mail Returned to Sender')
 
         require 'sisimai/datetime'
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/sendgrid.rb
+++ b/lib/sisimai/bite/email/sendgrid.rb
@@ -15,7 +15,6 @@ module Sisimai::Bite::Email
         :begin  => %r/\AThis is an automatically generated message from SendGrid[.]\z/,
         :error  => %r/\AIf you require assistance with this, please contact SendGrid support[.]\z/,
         :rfc822 => %r|\AContent-Type: message/rfc822|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/sendmail.rb
+++ b/lib/sisimai/bite/email/sendmail.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Sendmail.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from    => %r/\AMail Delivery Subsystem/,
-        :subject => %r/(?:see transcript for details\z|\AWarning: )/,
-      }.freeze
       # Error text regular expressions which defined in sendmail/savemail.c
       #   savemail.c:1040|if (printheader && !putline("   ----- Transcript of session follows -----\n",
       #   savemail.c:1041|          mci))
@@ -40,12 +36,12 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['subject'] =~ Re0[:subject]
 
+        return nil unless mhead['subject'] =~ /(?:see transcript for details\z|\AWarning: )/
         unless mhead['subject'] =~ /\A[ \t]*Fwd?:/i
           # Fwd: Returned mail: see transcript for details
           # Do not execute this code if the bounce mail is a forwarded message.
-          return nil unless mhead['from'] =~ Re0[:from]
+          return nil unless mhead['from'].start_with?('Mail Delivery Subsystem')
         end
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/sendmail.rb
+++ b/lib/sisimai/bite/email/sendmail.rb
@@ -19,7 +19,6 @@ module Sisimai::Bite::Email
         :begin   => %r/\A[ \t]+[-]+ Transcript of session follows [-]+\z/,
         :error   => %r/\A[.]+ while talking to .+[:]\z/,
         :rfc822  => %r{\AContent-Type:[ ]*(?:message/rfc822|text/rfc822-headers)\z},
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/surfcontrol.rb
+++ b/lib/sisimai/bite/email/surfcontrol.rb
@@ -7,10 +7,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/SurfControl.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'from'     => %r/ [(]Mail Delivery System[)]\z/,
-        :'x-mailer' => %r/\ASurfControl E-mail Filter\z/,
-      }.freeze
       Re1 = {
         :begin  => %r/\AYour message could not be sent[.]\z/,
         :error  => %r/\AFailed to send to identified host,\z/,
@@ -39,9 +35,11 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
+
+        # :'from' => %r/ [(]Mail Delivery System[)]\z/,
         return nil unless mhead['x-sef-processed']
         return nil unless mhead['x-mailer']
-        return nil unless mhead['x-mailer'] =~ Re0[:'x-mailer']
+        return nil unless mhead['x-mailer'].start_with?('SurfControl E-mail Filter')
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/surfcontrol.rb
+++ b/lib/sisimai/bite/email/surfcontrol.rb
@@ -15,7 +15,6 @@ module Sisimai::Bite::Email
         :begin  => %r/\AYour message could not be sent[.]\z/,
         :error  => %r/\AFailed to send to identified host,\z/,
         :rfc822 => %r|\AContent-Type: message/rfc822\z|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/userdefined.rb
+++ b/lib/sisimai/bite/email/userdefined.rb
@@ -6,13 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/UserDefined.pm
       require 'sisimai/bite/email'
 
-      # Re0 is a regular expression to match with message headers which are
-      # given as the first argument of scan() method.
-      Re0 = {
-        :from    => %r/\AMail Sysmet/,
-        :subject => %r/\AError Mail Report/,
-      }.freeze
-
       # Re1 is delimiter set of these sections:
       #   begin:  The first line of a bounce message to be parsed.
       #   error:  The first line of an error message to get an error reason, recipient
@@ -45,14 +38,14 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
 
-        match = 0
         # 1. Check some value in mhead using regular expression or "==" operator
         #    whether the bounce message should be parsed by this module or not.
         #   - Matched 1 or more values: Proceed to the step 2.
         #   - Did not matched:          return nil
         #
-        match += 1 if mhead['subject'] =~ Re0[:subject]
-        match += 1 if mhead['from']    =~ Re0[:from]
+        match  = 0
+        match += 1 if mhead['subject'].start_with?('Error Mail Report')
+        match += 1 if mhead['from'].include?('Mail System')
         match += 1 if mhead['x-some-userdefined-header']
         return nil if match.zero?
 

--- a/lib/sisimai/bite/email/userdefined.rb
+++ b/lib/sisimai/bite/email/userdefined.rb
@@ -23,7 +23,6 @@ module Sisimai::Bite::Email
         :begin   => %r/\A[ \t]+[-]+ Transcript of session follows [-]+\z/,
         :error   => %r/\A[.]+ while talking to .+[:]\z/,
         :rfc822  => %r{\AContent-Type:[ ]*(?:message/rfc822|text/rfc822-headers)\z},
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/v5sendmail.rb
+++ b/lib/sisimai/bite/email/v5sendmail.rb
@@ -7,10 +7,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/V5sendmail.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from    => %r/\AMail Delivery Subsystem/,
-        :subject => %r/\AReturned mail: [A-Z]/,
-      }.freeze
       # Error text regular expressions which defined in src/savemail.c
       #   savemail.c:485| (void) fflush(stdout);
       #   savemail.c:486| p = queuename(e->e_parent, 'x');
@@ -56,7 +52,9 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['subject'] =~ Re0[:subject]
+
+        # :from => %r/\AMail Delivery Subsystem/,
+        return nil unless mhead['subject'] =~ /\AReturned mail: [A-Z]/
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/v5sendmail.rb
+++ b/lib/sisimai/bite/email/v5sendmail.rb
@@ -35,7 +35,6 @@ module Sisimai::Bite::Email
           |No[ ]message[ ]was[ ]collected
           )[ ]-----
         }x,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/verizon.rb
+++ b/lib/sisimai/bite/email/verizon.rb
@@ -69,7 +69,6 @@ module Sisimai::Bite::Email
           re1 = {
             :begin  => %r/\AError:[ \t]/,
             :rfc822 => %r/\A__BOUNDARY_STRING_HERE__\z/,
-            :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
           }
           reFailure = {
             # The attempted recipient address does not exist.
@@ -150,7 +149,6 @@ module Sisimai::Bite::Email
           re1 = {
             :begin  => %r/\AMessage could not be delivered to mobile/,
             :rfc822 => %r/\A__BOUNDARY_STRING_HERE__\z/,
-            :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
           }
           reFailure = {
             userunknown: %r/No[ ]valid[ ]recipients[ ]for[ ]this[ ]MM/x,

--- a/lib/sisimai/bite/email/verizon.rb
+++ b/lib/sisimai/bite/email/verizon.rb
@@ -7,16 +7,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Verizon.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'received'  => %r/by .+[.]vtext[.]com /,
-        :'vtext.com' => {
-          :'from' => %r/\Apost_master[@]vtext[.]com\z/,
-        },
-        :'vzwpix.com' => {
-          :'from'    => %r/[<]?sysadmin[@].+[.]vzwpix[.]com[>]?\z/,
-          :'subject' => %r/Undeliverable Message/,
-        },
-      }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 
       def description; return 'Verizon Wireless: http://www.verizonwireless.com'; end
@@ -41,9 +31,10 @@ module Sisimai::Bite::Email
         match = -1
         while true
           # Check the value of "From" header
-          break unless mhead['received'].find { |a| a =~ Re0[:received] }
-          match = 1 if mhead['from'] =~ Re0[:'vtext.com'][:from]
-          match = 0 if mhead['from'] =~ Re0[:'vzwpix.com'][:from]
+          # :'subject' => %r/Undeliverable Message/,
+          break unless mhead['received'].find { |a| a =~ /by .+[.]vtext[.]com / }
+          match = 1 if mhead['from'].start_with?('post_master@vtext.com')
+          match = 0 if mhead['from'] =~ /[<]?sysadmin[@].+[.]vzwpix[.]com[>]?\z/
           break
         end
         return nil if match < 0

--- a/lib/sisimai/bite/email/x1.rb
+++ b/lib/sisimai/bite/email/x1.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/X1.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from    => %r/["]Mail Deliver System["] /,
-        :subject => %r/\AReturned Mail: /,
-      }.freeze
       Re1 = {
         :begin   => %r/\AThe original message was received at (.+)\z/,
         :rfc822  => %r/\AReceived: from \d+[.]\d+[.]\d+[.]\d/,
@@ -34,8 +30,8 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['subject'] =~ Re0[:subject]
-        return nil unless mhead['from']    =~ Re0[:from]
+        return nil unless mhead['subject'].start_with?('Returned Mail: ')
+        return nil unless mhead['from'].include?('"Mail Deliver System" ')
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/x1.rb
+++ b/lib/sisimai/bite/email/x1.rb
@@ -12,7 +12,6 @@ module Sisimai::Bite::Email
       }.freeze
       Re1 = {
         :begin   => %r/\AThe original message was received at (.+)\z/,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
         :rfc822  => %r/\AReceived: from \d+[.]\d+[.]\d+[.]\d/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS

--- a/lib/sisimai/bite/email/x2.rb
+++ b/lib/sisimai/bite/email/x2.rb
@@ -17,7 +17,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin  => %r/\AUnable to deliver message to the following address/,
         :rfc822 => %r/\A--- Original message follows/,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/x2.rb
+++ b/lib/sisimai/bite/email/x2.rb
@@ -6,14 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/X2.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from    => %r/MAILER-DAEMON[@]/,
-        :subject => %r{\A(?>
-           Delivery[ ]failure
-          |fail(?:ure|ed)[ ]delivery
-          )
-        }x,
-      }.freeze
       Re1 = {
         :begin  => %r/\AUnable to deliver message to the following address/,
         :rfc822 => %r/\A--- Original message follows/,
@@ -38,8 +30,8 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['subject'] =~ Re0[:subject]
-        return nil unless mhead['from']    =~ Re0[:from]
+        return nil unless mhead['from'].include?('MAILER-DAEMON@')
+        return nil unless mhead['subject'] =~ %r/\A(?>Delivery failure|fail(?:ure|ed) delivery)/
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/x3.rb
+++ b/lib/sisimai/bite/email/x3.rb
@@ -13,7 +13,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin  => %r/\A[ \t]+This is an automatically generated Delivery Status Notification/,
         :rfc822 => %r|\AContent-Type: message/rfc822|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/x3.rb
+++ b/lib/sisimai/bite/email/x3.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/X3.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from    => %r/\AMail Delivery System/,
-        :subject => %r/\ADelivery status notification/,
-      }.freeze
       Re1 = {
         :begin  => %r/\A[ \t]+This is an automatically generated Delivery Status Notification/,
         :rfc822 => %r|\AContent-Type: message/rfc822|,
@@ -34,8 +30,8 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        return nil unless mhead['subject'] =~ Re0[:subject]
-        return nil unless mhead['from']    =~ Re0[:from]
+        return nil unless mhead['subject'].start_with?('Delivery status notification')
+        return nil unless mhead['from'].start_with?('Mail Delivery System')
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/x4.rb
+++ b/lib/sisimai/bite/email/x4.rb
@@ -48,7 +48,6 @@ module Sisimai::Bite::Email
         }xi,
         :error  => %r/\ARemote host said:/,
         :sorry  => %r/\A[Ss]orry[,.][ ]/,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReSMTP = {
         # Error text regular expressions which defined in qmail-remote.c

--- a/lib/sisimai/bite/email/x4.rb
+++ b/lib/sisimai/bite/email/x4.rb
@@ -7,14 +7,6 @@ module Sisimai::Bite::Email
       # MTA module for qmail clones
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :subject  => %r{\A(?:
-           failure[ ]notice
-          |Permanent[ ]Delivery[ ]Failure
-          )
-        }xi,
-        :received => %r/\A[(]qmail[ ]+\d+[ ]+invoked[ ]+for[ ]+bounce[)]/,
-      }.freeze
       #  qmail-remote.c:248|    if (code >= 500) {
       #  qmail-remote.c:249|      out("h"); outhost(); out(" does not like recipient.\n");
       #  qmail-remote.c:265|  if (code >= 500) quit("D"," failed on DATA command");
@@ -167,8 +159,8 @@ module Sisimai::Bite::Email
         #   e.g.) Received: (qmail 12345 invoked for bounce); 29 Apr 2009 12:34:56 -0000
         #         Subject: failure notice
         match  = 0
-        match += 1 if mhead['subject'] =~ Re0[:subject]
-        match += 1 if mhead['received'].find { |a| a =~ Re0[:received] }
+        match += 1 if mhead['subject'].start_with?('failure notice', 'Permanent Delivery Failure')
+        match += 1 if mhead['received'].find { |a| a =~ /\A[(]qmail[ ]+\d+[ ]+invoked[ ]+for[ ]+bounce[)]/ }
         return nil if match.zero?
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/x5.rb
+++ b/lib/sisimai/bite/email/x5.rb
@@ -13,7 +13,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin  => %r|\AContent-Type: message/delivery-status|,
         :rfc822 => %r|\AContent-Type: message/rfc822|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/x5.rb
+++ b/lib/sisimai/bite/email/x5.rb
@@ -6,10 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/X5.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from => %r/\bTWFpbCBEZWxpdmVyeSBTdWJzeXN0ZW0\b/,
-        :to   => %r/\bNotificationRecipients\b/,
-      }.freeze
       Re1 = {
         :begin  => %r|\AContent-Type: message/delivery-status|,
         :rfc822 => %r|\AContent-Type: message/rfc822|,
@@ -34,13 +30,13 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
-        match = 0
 
         # To: "NotificationRecipients" <...>
-        match += 1 if mhead['to'] && mhead['to'] =~ Re0[:to]
+        match  = 0
+        match += 1 if mhead['to'] && mhead['to'] =~ /\bNotificationRecipients\b/
 
         require 'sisimai/mime'
-        if mhead['from'] =~ Re0[:from]
+        if mhead['from'] =~ /\bTWFpbCBEZWxpdmVyeSBTdWJzeXN0ZW0\b/
           # From: "=?iso-2022-jp?B?TWFpbCBEZWxpdmVyeSBTdWJzeXN0ZW0=?=" <...>
           #       Mail Delivery Subsystem
           mhead['from'].split(' ').each do |f|

--- a/lib/sisimai/bite/email/yahoo.rb
+++ b/lib/sisimai/bite/email/yahoo.rb
@@ -6,9 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Yahoo.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :subject => %r/\AFailure Notice\z/,
-      }.freeze
       Re1 = {
         :begin   => %r/\ASorry, we were unable to deliver your message/,
         :rfc822  => %r/\A--- Below this line is a copy of the message[.]\z/,
@@ -38,6 +35,8 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
+
+        # :subject => %r/\AFailure Notice\z/,
         return nil unless mhead['x-ymailisg']
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/bite/email/yahoo.rb
+++ b/lib/sisimai/bite/email/yahoo.rb
@@ -12,7 +12,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin   => %r/\ASorry, we were unable to deliver your message/,
         :rfc822  => %r/\A--- Below this line is a copy of the message[.]\z/,
-        :endof   => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/yandex.rb
+++ b/lib/sisimai/bite/email/yandex.rb
@@ -6,9 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Yandex.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :from   => %r/\Amailer-daemon[@]yandex[.]ru\z/,
-      }.freeze
       Re1 = {
         :begin  => %r/\AThis is the mail system at host yandex[.]ru[.]/,
         :rfc822 => %r|\AContent-Type: message/rfc822|,
@@ -42,7 +39,7 @@ module Sisimai::Bite::Email
         return nil unless mhead
         return nil unless mbody
         return nil unless mhead['x-yandex-uniq']
-        return nil unless mhead['from'] =~ Re0[:from]
+        return nil unless mhead['from'].start_with?('mailer-daemon@yandex.ru')
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]
         hasdivided = mbody.split("\n")

--- a/lib/sisimai/bite/email/yandex.rb
+++ b/lib/sisimai/bite/email/yandex.rb
@@ -12,7 +12,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin  => %r/\AThis is the mail system at host yandex[.]ru[.]/,
         :rfc822 => %r|\AContent-Type: message/rfc822|,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       Indicators = Sisimai::Bite::Email.INDICATORS
 

--- a/lib/sisimai/bite/email/zoho.rb
+++ b/lib/sisimai/bite/email/zoho.rb
@@ -18,7 +18,6 @@ module Sisimai::Bite::Email
       Re1 = {
         :begin  => %r/\AThis message was created automatically by mail delivery/,
         :rfc822 => %r/\AReceived:[ \t]*from mail[.]zoho[.]com/,
-        :endof  => %r/\A__END_OF_EMAIL_MESSAGE__\z/,
       }.freeze
       ReFailure = {
         expired: %r/Host not reachable/

--- a/lib/sisimai/bite/email/zoho.rb
+++ b/lib/sisimai/bite/email/zoho.rb
@@ -6,15 +6,6 @@ module Sisimai::Bite::Email
       # Imported from p5-Sisimail/lib/Sisimai/Bite/Email/Zoho.pm
       require 'sisimai/bite/email'
 
-      Re0 = {
-        :'from'     => %r/mailer-daemon[@]mail[.]zoho[.]com\z/,
-        :'subject'  => %r{\A(?:
-             Undelivered[ ]Mail[ ]Returned[ ]to[ ]Sender
-            |Mail[ ]Delivery[ ]Status[ ]Notification
-            )
-        }x,
-        :'x-mailer' => %r/\AZoho Mail\z/,
-      }.freeze
       Re1 = {
         :begin  => %r/\AThis message was created automatically by mail delivery/,
         :rfc822 => %r/\AReceived:[ \t]*from mail[.]zoho[.]com/,
@@ -46,6 +37,14 @@ module Sisimai::Bite::Email
       def scan(mhead, mbody)
         return nil unless mhead
         return nil unless mbody
+
+        # :'from'     => %r/mailer-daemon[@]mail[.]zoho[.]com\z/,
+        # :'subject'  => %r{\A(?:
+        #      Undelivered[ ]Mail[ ]Returned[ ]to[ ]Sender
+        #     |Mail[ ]Delivery[ ]Status[ ]Notification
+        #     )
+        # }x,
+        # :'x-mailer' => %r/\AZoho Mail\z/,
         return nil unless mhead['x-zohomail']
 
         dscontents = [Sisimai::Bite.DELIVERYSTATUS]

--- a/lib/sisimai/mda.rb
+++ b/lib/sisimai/mda.rb
@@ -3,9 +3,6 @@ module Sisimai
   module MDA
     # Imported from p5-Sisimail/lib/Sisimai/MDA.pm
     class << self
-      Re0 = {
-        :from => %r/\A(?:Mail Delivery Subsystem|MAILER-DAEMON|postmaster)/i,
-      }.freeze
       Re1 = {
         # dovecot/src/deliver/deliver.c
         # 11: #define DEFAULT_MAIL_REJECTION_HUMAN_REASON \
@@ -96,8 +93,7 @@ module Sisimai
         return nil unless mbody
         return nil if mhead.keys.size.zero?
         return nil if mbody.empty?
-
-        return nil unless mhead['from'] =~ Re0[:from]
+        return nil unless mhead['from'] =~ /\A(?:Mail Delivery Subsystem|MAILER-DAEMON|postmaster)/i
 
         agentname0 = ''   # [String] MDA name
         reasonname = ''   # [String] Error reason

--- a/lib/sisimai/rfc3464.rb
+++ b/lib/sisimai/rfc3464.rb
@@ -6,20 +6,6 @@ module Sisimai
       require 'sisimai/bite/email'
 
       # http://tools.ietf.org/html/rfc3464
-      Re0 = {
-        :'from'        => %r/\b(?:postmaster|mailer-daemon|root)[@]/i,
-        :'return-path' => %r/(?:[<][>]|mailer-daemon)/i,
-        :'subject'     => %r{(?>
-           delivery[ ](?:failed|failure|report)
-          |failure[ ]notice
-          |mail[ ](?:delivery|error)
-          |non[-]delivery
-          |returned[ ]mail
-          |undeliverable[ ]mail
-          |Warning:[ ]
-          )
-        }xi,
-      }.freeze
       Re1 = {
         :begin   => %r{\A(?>
            Content-Type:[ ]*(?:
@@ -315,12 +301,21 @@ module Sisimai
           match = 0
 
           # Failed to get a recipient address at code above
-          match += 1 if mhead['from']    =~ Re0[:from]
-          match += 1 if mhead['subject'] =~ Re0[:subject]
+          match += 1 if mhead['from'] =~ /\b(?:postmaster|mailer-daemon|root)[@]/i
+          match += 1 if mhead['subject'] =~ %r{(?>
+             delivery[ ](?:failed|failure|report)
+            |failure[ ]notice
+            |mail[ ](?:delivery|error)
+            |non[-]delivery
+            |returned[ ]mail
+            |undeliverable[ ]mail
+            |Warning:[ ]
+            )
+          }xi
 
           if mhead['return-path']
             # Check the value of Return-Path of the message
-            match += 1 if mhead['return-path'] =~ Re0[:'return-path']
+            match += 1 if mhead['return-path'] =~ /(?:[<][>]|mailer-daemon)/i
           end
           break unless match > 0
 

--- a/lib/sisimai/rfc3834.rb
+++ b/lib/sisimai/rfc3834.rb
@@ -20,7 +20,6 @@ module Sisimai
       }.freeze
       Re1 = {
         :boundary => %r/\A__SISIMAI_PSEUDO_BOUNDARY__\z/,
-        :endof    => %r/\A__END_OF_EMAIL_MESSAGE__\z/
       }
       Re2 = {
         :subject => %r/(?:

--- a/set-of-emails/maildir/bsd/README.md
+++ b/set-of-emails/maildir/bsd/README.md
@@ -13,173 +13,173 @@ Sisimai::ARF
 
 Sisimai::MTA::Exchange2003
 --------------------------------------------------------------------------------
-* mta-exchange-06.eml
+* email-exchange-06.eml
   * mailman-2.1.15/tests/bounces/groupwise_01.txt
   * Copyright (C) 1989, 1991 Free Software Foundation, Inc. | GPLv2
 
 Sisimai::MTA::Exchange2007
 --------------------------------------------------------------------------------
-* mta-exchange2007-02.eml
+* email-exchange2007-02.eml
   * [message-too-large.msg](https://github.com/rjbs/Mail-DeliveryStatus-BounceParser/blob/master/t/corpus/message-too-large.msg)
   * Copyright (C) 2003-2006 IC Group, Inc. | GPLv2
 
-* mta-exchange2007-03.eml
+* email-exchange2007-03.eml
   * https://github.com/LoneStarInternet/mail_manager/tree/master/spec/test_app/spec/support/files/bounce-mail-box-full.txt
   * Copyright (c) 2015 Lone Star Internet, Inc. | MIT
 
 Sisimai::MTA::Exim
 --------------------------------------------------------------------------------
-* mta-exim-09.eml
+* email-exim-09.eml
   * [13.eml](https://github.com/prasad83/node-bounce-handler/blob/master/eml/13.eml)
   * Copyright (c) 2014 prasad83 | The MIT License
 
-* mta-exim-10.eml
+* email-exim-10.eml
   * [34.eml](https://github.com/prasad83/node-bounce-handler/blob/master/eml/34.eml)
   * Copyright (c) 2014 prasad83 | The MIT License
 
-* mta-exim-11.eml
+* email-exim-11.eml
   * [44.eml](https://github.com/prasad83/node-bounce-handler/blob/master/eml/44.eml)
   * Copyright (c) 2014 prasad83 | The MIT License
 
-* mta-exim-12.eml
+* email-exim-12.eml
   * [0224.CALLER](https://github.com/Exim/exim/blob/master/test/mail/0224.CALLER)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-13.eml
+* email-exim-13.eml
   * [0237.CALLER](https://github.com/Exim/exim/blob/master/test/mail/0237.CALLER)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-14.eml
+* email-exim-14.eml
   * [9001.CALLER](https://github.com/Exim/exim/blob/master/test/mail/9001.CALLER)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-15.eml
+* email-exim-15.eml
   * [0536.oksender](https://github.com/Exim/exim/blob/master/test/mail/0536.oksender)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-16.eml
+* email-exim-16.eml
   * [0522.CALLER](https://github.com/Exim/exim/blob/master/test/mail/0522.CALLER)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-17.eml
+* email-exim-17.eml
   * [0310.CALLER](https://github.com/Exim/exim/blob/master/test/mail/0310.CALLER)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-18.eml
+* email-exim-18.eml
   * [0280.CALLER](https://github.com/Exim/exim/blob/master/test/mail/0280.CALLER)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-19.eml
+* email-exim-19.eml
   * [0174.CALLER](https://github.com/Exim/exim/blob/master/test/mail/0174.CALLER)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-20.eml
+* email-exim-20.eml
   * [0531.CALLER](https://github.com/Exim/exim/blob/master/test/mail/0531.CALLER)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-21.eml
+* email-exim-21.eml
   * [0461.CALLER](https://github.com/Exim/exim/blob/master/test/mail/0461.CALLER)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-22.eml
+* email-exim-22.eml
   * [0321.CALLER](https://github.com/Exim/exim/blob/master/test/mail/0321.CALLER)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-23.eml
+* email-exim-23.eml
   * [0253.lmn](https://github.com/Exim/exim/blob/master/test/mail/0253.lmn)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-24.eml
+* email-exim-24.eml
   * [0136.forwarder](https://github.com/Exim/exim/blob/master/test/mail/0136.forwarder)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-25.eml
+* email-exim-25.eml
   * [0233.me](https://github.com/Exim/exim/blob/master/test/mail/0233.me)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-26.eml
+* email-exim-26.eml
   * [0015.CALLER](https://github.com/Exim/exim/blob/master/test/mail/0015.CALLER)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-27.eml
+* email-exim-27.eml
   * [0211.CALLER](https://github.com/Exim/exim/blob/master/test/mail/0211.CALLER)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
-* mta-exim-28.eml
+* email-exim-28.eml
   * [0226.CALLER](https://github.com/Exim/exim/blob/master/test/mail/0226.CALLER)
   * Copyright (c) 1995 - 2012 University of Cambridge.
 
 Sisimai::MTA::IMailServer
 --------------------------------------------------------------------------------
-* mta-imailserver-05.eml
+* email-imailserver-05.eml
   * mailman-2.1.15/tests/bounces/smtp32_03.txt
   * Copyright (C) 1989, 1991 Free Software Foundation, Inc. | GPLv2
 
 Sisimai::MTA::InterScanMSS
 --------------------------------------------------------------------------------
-* mta-interscanmss-02.eml
+* email-interscanmss-02.eml
   * mailman-2.1.15/tests/bounces/simple_15.txt
   * Copyright (C) 1989, 1991 Free Software Foundation, Inc. | GPLv2
 
 Sisimai::MTA::Notes
 --------------------------------------------------------------------------------
-* mta-notes-04.eml
+* email-notes-04.eml
   * [msg00154.html](http://osdir.com/ml/org.telecom.india-gii/2003-02/msg00154.html)
   * Copyrighted (c) 2000-2015, but we're happy to let you use what you wish with attribution. OSDir.com
 
 Sisimai::MTA::Postfix
 --------------------------------------------------------------------------------
-* mta-postfix-18.eml
+* email-postfix-18.eml
   * [relay_failed.eml](https://github.com/choonkeat/deliveryboy/blob/master/spec/fixtures/bounce_cases/relay_failed.eml)
   * Copyright (c) 2011 Chew Choon Keat | The MIT License
 
-* mta-postfix-19.eml
+* email-postfix-19.eml
   * [testfile.eml](https://github.com/prasad83/node-bounce-handler/blob/master/eml/testfile.eml)
   * Copyright (c) 2011 Chew Choon Keat | The MIT License
 
-* mta-postfix-20.eml
+* email-postfix-20.eml
   * mailman-2.1.15/tests/bounces/postfix_05.txt
   * Copyright (C) 1989, 1991 Free Software Foundation, Inc. | GPLv2
 
-* mta-postfix-22.eml
+* email-postfix-22.eml
   * https://github.com/LoneStarInternet/mail_manager/tree/master/spec/test_app/spec/support/files/bounce_400.txt
   * Copyright (c) 2015 Lone Star Internet, Inc. | MIT
 
-* mta-postfix-23.eml
+* email-postfix-23.eml
   * https://github.com/LoneStarInternet/mail_manager/tree/master/spec/test_app/spec/support/files/bounce_500.txt
   * Copyright (c) 2015 Lone Star Internet, Inc. | MIT
 
-* mta-postfix-24.eml
+* email-postfix-24.eml
   * https://github.com/LoneStarInternet/mail_manager/tree/master/spec/test_app/spec/support/files/bounce-invalid-address.txt
   * Copyright (c) 2015 Lone Star Internet, Inc. | MIT
 
-* mta-postfix-25.eml
+* email-postfix-25.eml
   * https://github.com/LoneStarInternet/mail_manager/tree/master/spec/test_app/spec/support/files/bounce-smtp-timeout.txt
   * Copyright (c) 2015 Lone Star Internet, Inc. | MIT
 
-* mta-postfix-26.eml
+* email-postfix-26.eml
   * https://github.com/LoneStarInternet/mail_manager/tree/master/spec/test_app/spec/support/files/bounce-unknown_domain.txt
   * Copyright (c) 2015 Lone Star Internet, Inc. | MIT
 
-* mta-postfix-27.eml
+* email-postfix-27.eml
   * https://github.com/rgl/MailBounceDetector/blob/master/MailBounceDetector.Tests/Fixtures/bounce_postfix_non_existing_mailbox.eml
   * Copyright (c) 2015 Rui Lopes (ruilopes.com) | MIT
 
 Sisimai::MTA::qmail
 --------------------------------------------------------------------------------
-* mta-qmail-09.eml
+* email-qmail-09.eml
   * mailman-2.1.15/tests/bounces/qmail_01.txt
   * Copyright (C) 1989, 1991 Free Software Foundation, Inc. | GPLv2
 
-* mta-qmail-10.eml
+* email-qmail-10.eml
   * https://github.com/rgl/MailBounceDetector/blob/master/MailBounceDetector.Tests/Fixtures/bounce_qmail_extra_lines_between_recipient_paragraphs.eml
   * Copyright (c) 2015 Rui Lopes (ruilopes.com) | MIT
 
-* mta-qmail-11.eml
+* email-qmail-11.eml
   * https://github.com/rgl/MailBounceDetector/blob/master/MailBounceDetector.Tests/Fixtures/bounce_qmail_multipart_alternative_non_existing_mailbox.eml
   * Copyright (c) 2015 Rui Lopes (ruilopes.com) | MIT
 
-* mta-qmail-12.eml
+* email-qmail-12.eml
   * https://github.com/rgl/MailBounceDetector/blob/master/MailBounceDetector.Tests/Fixtures/bounce_qmail_no_host_found.eml
   * Copyright (c) 2015 Rui Lopes (ruilopes.com) | MIT
 
@@ -273,55 +273,55 @@ Sisimai::RFC3834
 
 Sisimai::MTA::Sendmail
 --------------------------------------------------------------------------------
-* mta-sendmail-23.eml
+* email-sendmail-23.eml
   * [DSN-spam.eml](https://github.com/sendgrid/go-gmime/blob/master/gmime/fixtures/DSN-spam.eml)
   * Copyright (c) 2014, 2015 SendGrid Inc. | The MIT License
 
 Sisimai::MSP::US::Google
 --------------------------------------------------------------------------------
-* us-msp-google-12.eml
+* email-google-12.eml
   * mailman-2.1.15/tests/bounces/simple_17.txt
   * Copyright (C) 1989, 1991 Free Software Foundation, Inc. | GPLv2
 
-* us-msp-google-13.eml
+* email-google-13.eml
   * mailman-2.1.15/tests/bounces/simple_28.txt
   * Copyright (C) 1989, 1991 Free Software Foundation, Inc. | GPLv2
 
 Sisimai::MSP::US::Outlook
 --------------------------------------------------------------------------------
-* us-msp-outlook-09.eml
+* email-outlook-09.eml
   * [connection_timed_out.eml](https://github.com/choonkeat/deliveryboy/blob/master/spec/fixtures/bounce_cases/connection_timed_out.eml)
   * Copyright (c) 2011 Chew Choon Keat | The MIT License
 
 Sisimai::MTA::X2
 --------------------------------------------------------------------------------
-* mta-x2-05.eml
+* email-x2-05.eml
   * mailman-2.1.15/tests/bounces/yahoo_03.txt
   * Copyright (C) 1989, 1991 Free Software Foundation, Inc. | GPLv2
 
 Sisimai::MTA::X4
 --------------------------------------------------------------------------------
-* mta-x4-01.eml
+* email-x4-01.eml
   * [bounce-secureservers.net-mailfolder_is_full.eml](https://github.com/justingit/dada-mail/blob/master/dada/t/corpus/email_messages/bounce-secureservers.net-mailfolder_is_full.eml)
   * Copyright (c) 1999 - 2015 Justin Simoni | GPL
 
-* mta-x4-02.eml
+* email-x4-02.eml
   * mailman-2.1.15/tests/bounces/newmailru_01.txt
   * Copyright (C) 1989, 1991 Free Software Foundation, Inc. | GPLv2
 
-* mta-x4-03.eml
+* email-x4-03.eml
   * mailman-2.1.15/tests/bounces/qmail_03.txt
   * Copyright (C) 1989, 1991 Free Software Foundation, Inc. | GPLv2
 
-* mta-x4-04.eml
+* email-x4-04.eml
   * mailman-2.1.15/tests/bounces/qmail_04.txt
   * Copyright (C) 1989, 1991 Free Software Foundation, Inc. | GPLv2
 
-* mta-x4-05.eml
+* email-x4-05.eml
   * mailman-2.1.15/tests/bounces/qmail_05.txt
   * Copyright (C) 1989, 1991 Free Software Foundation, Inc. | GPLv2
 
-* mta-x4-06.eml
+* email-x4-06.eml
   * mailman-2.1.15/tests/bounces/qmail_06.txt
   * Copyright (C) 1989, 1991 Free Software Foundation, Inc. | GPLv2
 


### PR DESCRIPTION
String#=~ will be replaced with

- String#start_with?
- String#end_with?
- String#include?

Follow up pull-request #105.
