### PR TITLE
Loosen Oj gem restriction to just >= 3.0.0

### DIFF
--- a/sisimai.gemspec
+++ b/sisimai.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.8'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 0'
-  spec.add_runtime_dependency 'oj', '~> 3.0.0', '>= 3.0.0'
+  spec.add_runtime_dependency 'oj', '>= 3.0.0'
 end


### PR DESCRIPTION
All specs seem to pass with this restriction. Let me know if this is problematic.