### PR TITLE
Allow to use StringIO instead of IO

### DIFF
--- a/lib/sisimai.rb
+++ b/lib/sisimai.rb
@@ -35,7 +35,7 @@ module Sisimai
 
       unless input
         # "input" did not specified, try to detect automatically.
-        if argv0.is_a?(::String) || argv0.is_a?(IO)
+        if argv0.is_a?(::String) || argv0.is_a?(IO) || argv0.is_a?(StringIO)
           # The argument may be a path to email OR an email text
           input = 'email'
 

--- a/lib/sisimai/mail.rb
+++ b/lib/sisimai/mail.rb
@@ -48,7 +48,7 @@ module Sisimai
             parameter['path'] = 'MEMORY'
           end
         end
-      elsif argv1.is_a?(IO)
+      elsif argv1.is_a?(IO) || argv1.is_a?(StringIO)
         # Read from STDIN
         # The argument neither a mailbox nor a Maildir/.
         classname = self.class.to_s << '::STDIN'

--- a/lib/sisimai/mail/stdin.rb
+++ b/lib/sisimai/mail/stdin.rb
@@ -20,7 +20,7 @@ module Sisimai
       # @param    [IO::STDIN] stdin      Standard-In
       # @return   [Sisimai::Mail::STDIN] Object
       def initialize(stdin = $stdin)
-        raise 'is not an IO object' unless stdin.is_a?(IO)
+        raise 'is not an IO object' unless stdin.is_a?(IO) || stdin.is_a?(StringIO)
 
         @path   = '<STDIN>'
         @name   = '<STDIN>'


### PR DESCRIPTION
This change allows to use `Sisimai.make` even if a mail source is given as a `String`.
`Sisimai.make(StringIO.new(mail_source_string))`