### PR TITLE
Bug fix in Sisimai::Bite::Email::Xxx.scan

### DIFF
--- a/lib/sisimai/bite/email/biglobe.rb
+++ b/lib/sisimai/bite/email/biglobe.rb
@@ -98,7 +98,7 @@ module Sisimai::Bite::Email
               # ********@***.biglobe.ne.jp
               if v['recipient']
                 # There are multiple recipient addresses in the message body.
-                push dscontents << Sisimai::Bite.DELIVERYSTATUS
+                dscontents << Sisimai::Bite.DELIVERYSTATUS
                 v = dscontents[-1]
               end
 

--- a/lib/sisimai/bite/email/ezweb.rb
+++ b/lib/sisimai/bite/email/ezweb.rb
@@ -138,7 +138,7 @@ module Sisimai::Bite::Email
 
               if v['recipient']
                 # There are multiple recipient addresses in the message body.
-                push dscontents << Sisimai::Bite.DELIVERYSTATUS
+                dscontents << Sisimai::Bite.DELIVERYSTATUS
                 v = dscontents[-1]
               end
 

--- a/lib/sisimai/bite/email/kddi.rb
+++ b/lib/sisimai/bite/email/kddi.rb
@@ -95,7 +95,7 @@ module Sisimai::Bite::Email
               #     As their mailbox is full.
               if v['recipient']
                 # There are multiple recipient addresses in the message body.
-                push dscontents << Sisimai::Bite.DELIVERYSTATUS
+                dscontents << Sisimai::Bite.DELIVERYSTATUS
                 v = dscontents[-1]
               end
 


### PR DESCRIPTION
This change fixes the following error.
```
NoMethodError: undefined method `push' for Sisimai::Bite::Email::EZweb:Module
lib/sisimai/bite/email/ezweb.rb:141:in `scan'
```