### PR TITLE
Fix NoMethodError bug for specific types of mails from postfix

### DIFF
--- a/lib/sisimai/bite/email/postfix.rb
+++ b/lib/sisimai/bite/email/postfix.rb
@@ -160,7 +160,7 @@ module Sisimai::Bite::Email
 
                 elsif p.start_with?('Diagnostic-Code:') && cv = e.match(/\A[ \t]+(.+)\z/)
                   # Continued line of the value of Diagnostic-Code header
-                  v['diagnosis'] << ' ' << cv[1]
+                  v['diagnosis'] = ' ' << cv[1]
                   havepassed[-1] = 'Diagnostic-Code: ' << e
                 end
               end


### PR DESCRIPTION
When bounce contained something like that:

```
Diagnostic-Code: x-unix;
    /var/email/aweb200p1/Maildir/tmp/1534925367.M687651P13389.www10: Disk quota
    exceeded
```

It hit that part of code in `/lib/sisimai/bite/email/postfix.rb`:

```
elsif p.start_with?('Diagnostic-Code:') && cv = e.match(/\A[ \t]+(.+)\z/)
                  # Continued line of the value of Diagnostic-Code header
                  v['diagnosis'] << ' ' << cv[1]
                  havepassed[-1] = 'Diagnostic-Code: ' << e
                end
```

which caused this error:

```bundler: failed to load command: bouncer (/opt/rh/rh-ruby24/root/usr/local/share/gems/bin/bouncer)
NoMethodError: undefined method `<<' for nil:NilClass
  /opt/rh/rh-ruby24/root/usr/local/share/gems/gems/sisimai-4.22.7/lib/sisimai/bite/email/postfix.rb:175:in `scan'
  /opt/rh/rh-ruby24/root/usr/local/share/gems/gems/sisimai-4.22.7/lib/sisimai/message/email.rb:500:in `block (2 levels) in parse'
  /opt/rh/rh-ruby24/root/usr/local/share/gems/gems/sisimai-4.22.7/lib/sisimai/message/email.rb:495:in `each'
  /opt/rh/rh-ruby24/root/usr/local/share/gems/gems/sisimai-4.22.7/lib/sisimai/message/email.rb:495:in `block in parse'
  /opt/rh/rh-ruby24/root/usr/local/share/gems/gems/sisimai-4.22.7/lib/sisimai/message/email.rb:471:in `catch'
  /opt/rh/rh-ruby24/root/usr/local/share/gems/gems/sisimai-4.22.7/lib/sisimai/message/email.rb:471:in `parse'
  /opt/rh/rh-ruby24/root/usr/local/share/gems/gems/sisimai-4.22.7/lib/sisimai/message/email.rb:87:in `make'
  /opt/rh/rh-ruby24/root/usr/local/share/gems/gems/sisimai-4.22.7/lib/sisimai/message.rb:85:in `initialize'
  /usr/src/app/lib/bouncer.rb:140:in `new'
  /usr/src/app/lib/bouncer.rb:140:in `process_email'
  /usr/src/app/lib/bouncer.rb:188:in `process'
  /usr/src/app/lib/bouncer.rb:275:in `run'
  /usr/src/app/exe/bouncer:44:in `<top (required)>'
  /opt/rh/rh-ruby24/root/usr/local/share/gems/bin/bouncer:23:in `load'
  /opt/rh/rh-ruby24/root/usr/local/share/gems/bin/bouncer:23:in `<top (required)>'```