### PR TITLE
Exchange 550 5.4.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,9 @@ v4.25.0p1
   - Fix code at `Sisimai::Message::Email.takeapart` method to decode a Subject
     header of the original message.
   - #147 Update error messages for Low Reputation Error from Gmail.
+  - Parser code to read bounce mails from m-FILTER at `Sisimai::Message::Email`
+    has been improved.
+  - Status 5.4.1 from Exchange Online is classified into "rejected" reason.
 
 v4.25.0
 --------------------------------------------------------------------------------

--- a/lib/sisimai/message/email.rb
+++ b/lib/sisimai/message/email.rb
@@ -413,6 +413,7 @@ module Sisimai
           mailheader['subject'] = Sisimai::MIME.mimedecode(mailheader['subject'].split(/[ ]/))
           mailheader['subject'].scrub!('?')
         end
+        bodystring = bodystring.scrub('?').delete("\r")
         bodystring << EndOfEmail
         haveloaded = {}
         scannedset = nil

--- a/lib/sisimai/reason/rejected.rb
+++ b/lib/sisimai/reason/rejected.rb
@@ -44,6 +44,7 @@ module Sisimai
           'message rejected: email address is not verified',
           'mx records for ',
           'null sender is not allowed',
+          'recipient addresses rejected : access denied',
           'recipient not accepted. (batv: no tag',
           'returned mail not accepted here',
           'rfc 1035 violation: recursive cname records for',

--- a/lib/sisimai/rhost/exchangeonline.rb
+++ b/lib/sisimai/rhost/exchangeonline.rb
@@ -25,7 +25,7 @@ module Sisimai
           '5.3.3'  => [{ reason: 'systemfull',  string: 'Unrecognized command' }],
           '5.3.4'  => [{ reason: 'mesgtoobig',  string: 'Message too big for system' }],
           '5.3.5'  => [{ reason: 'systemerror', string: 'System incorrectly configured' }],
-          '5.4.1'  => [{ reason: 'userunknown', string: 'Recipient address rejected: Access denied' }],
+          '5.4.1'  => [{ reason: 'rejected',    string: 'Recipient address rejected: Access denied' }],
           '5.4.14' => [{ reason: 'networkerror',string: 'Hop count exceeded' }],
           '5.5.2'  => [{ reason: 'syntaxerror', string: 'Send hello first' }],
           '5.5.3'  => [{ reason: 'syntaxerror', string: 'Too many recipients' }],

--- a/spec/sisimai/bite/email/private-mfilter_spec.rb
+++ b/spec/sisimai/bite/email/private-mfilter_spec.rb
@@ -9,6 +9,7 @@ isexpected = [
   { 'n' => '01005', 'r' => /userunknown/ },
   { 'n' => '01006', 'r' => /filtered/ },
   { 'n' => '01007', 'r' => /filtered/ },
+  { 'n' => '01008', 'r' => /rejected/ },
 ]
 Sisimai::Bite::Email::Code.maketest(enginename, isexpected, true)
 

--- a/spec/sisimai/bite/email/private-postfix_spec.rb
+++ b/spec/sisimai/bite/email/private-postfix_spec.rb
@@ -181,7 +181,7 @@ isexpected = [
   { 'n' => '01177', 'r' => /userunknown/ },
   { 'n' => '01178', 'r' => /blocked/ },
   { 'n' => '01179', 'r' => /norelaying/ },
-  { 'n' => '01180', 'r' => /userunknown/ },
+  { 'n' => '01180', 'r' => /rejected/ },
   { 'n' => '01181', 'r' => /userunknown/ },
   { 'n' => '01182', 'r' => /spamdetected/ },
   { 'n' => '01183', 'r' => /userunknown/ },
@@ -214,6 +214,7 @@ isexpected = [
   { 'n' => '01210', 'r' => /blocked/ },
   { 'n' => '01211', 'r' => /userunknown/ },
   { 'n' => '01212', 'r' => /userunknown/ },
+  { 'n' => '01213', 'r' => /userunknown/ },
 ]
 Sisimai::Bite::Email::Code.maketest(enginename, isexpected, true)
 

--- a/spec/sisimai/bite/email/public-postfix_spec.rb
+++ b/spec/sisimai/bite/email/public-postfix_spec.rb
@@ -20,7 +20,7 @@ isexpected = [
   { 'n' => '17', 's' => /\A5[.]4[.]4\z/,   'r' => /networkerror/,  'b' => /\A1\z/ },
   { 'n' => '28', 's' => /\A5[.]7[.]1\z/,   'r' => /policyviolation/, 'b' => /\A1\z/ },
   { 'n' => '29', 's' => /\A5[.]7[.]1\z/,   'r' => /policyviolation/, 'b' => /\A1\z/ },
-  { 'n' => '30', 's' => /\A5[.]4[.]1\z/,   'r' => /userunknown/,   'b' => /\A0\z/ },
+  { 'n' => '30', 's' => /\A5[.]4[.]1\z/,   'r' => /rejected/,      'b' => /\A1\z/ },
   { 'n' => '31', 's' => /\A5[.]1[.]1\z/,   'r' => /userunknown/,   'b' => /\A0\z/ },
   { 'n' => '32', 's' => /\A5[.]1[.]1\z/,   'r' => /userunknown/,   'b' => /\A0\z/ },
   { 'n' => '33', 's' => /\A5[.]1[.]1\z/,   'r' => /userunknown/,   'b' => /\A0\z/ },

--- a/spec/sisimai/rhost/exchangeonline_spec.rb
+++ b/spec/sisimai/rhost/exchangeonline_spec.rb
@@ -7,7 +7,7 @@ require 'sisimai/rhost/exchangeonline'
 describe Sisimai::Rhost::ExchangeOnline do
   rs = {
     '01' => { 'status' => %r/\A5[.]7[.]606\z/, 'reason' => %r/blocked/ },
-    '02' => { 'status' => %r/\A5[.]4[.]1\z/,   'reason' => %r/userunknown/ },
+    '02' => { 'status' => %r/\A5[.]4[.]1\z/,   'reason' => %r/rejected/ },
     '03' => { 'status' => %r/\A5[.]1[.]10\z/,  'reason' => %r/userunknown/ },
   }
   describe 'bounce mail from Exchange Online' do


### PR DESCRIPTION
- Import Pull-Request sisimai/p5-Sisimai#317
- https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/non-delivery-reports-in-exchange-online/fix-error-code-550-5-4-1-in-exchange-online
- Parser code to read bounce mails from m-FILTER at Sisimai::Message::Email has been improved. 
- Status 5.4.1 from Exchange Online is classified into "rejected" reason.
