### PR TITLE
v4.25.3p1

### DIFF
--- a/lib/sisimai/bite/email/mfilter.rb
+++ b/lib/sisimai/bite/email/mfilter.rb
@@ -11,7 +11,7 @@ module Sisimai::Bite::Email
       StartingOf = {
         error:   ['-------server message'],
         command: ['-------SMTP command'],
-        rfc822:  ['-------original message', '--------original mail info'],
+        rfc822:  ['-------original message', '-------original mail info'],
       }.freeze
       MarkingsOf = { message: %r/\A[^ ]+[@][^ ]+[.][a-zA-Z]+\z/ }.freeze
 

--- a/lib/sisimai/message/email.rb
+++ b/lib/sisimai/message/email.rb
@@ -310,7 +310,7 @@ module Sisimai
         if Sisimai::String.is_8bit(headerpart['subject'])
           # The value of ``Subject'' header is including multibyte character,
           # is not MIME-Encoded text.
-          headerpart['subject'] = 'MULTIBYTE CHARACTERS HAVE BEEN REMOVED'
+          headerpart['subject'].scrub!('?')
         else
           # MIME-Encoded subject field or ASCII characters only
           r = []

--- a/spec/sisimai/bite/email/code.rb
+++ b/spec/sisimai/bite/email/code.rb
@@ -226,6 +226,7 @@ module Sisimai
 
                         it(sprintf("%s #replycode is not nil", lb))      { expect(pr.replycode).not_to be nil }
                         it(sprintf("%s #subject is not nil", lb))        { expect(pr.subject).not_to be nil }
+                        it(sprintf("%s #subject is a valid string", lb)) { expect(pr.subject).not_to match(/\AMULTIBYTE/) }
                         it(sprintf("%s #smtpcommand is not nil", lb))    { expect(pr.smtpcommand).not_to be nil }
                         it(sprintf("%s #diagnosticcode is not nil", lb)) { expect(pr.diagnosticcode).not_to be nil }
                         it(sprintf("%s #diagnostictype is not nil", lb)) { expect(pr.diagnostictype).not_to be nil }

--- a/spec/sisimai/bite/email/private-mfilter_spec.rb
+++ b/spec/sisimai/bite/email/private-mfilter_spec.rb
@@ -10,6 +10,7 @@ isexpected = [
   { 'n' => '01006', 'r' => /filtered/ },
   { 'n' => '01007', 'r' => /filtered/ },
   { 'n' => '01008', 'r' => /rejected/ },
+  { 'n' => '01009', 'r' => /rejected/ },
 ]
 Sisimai::Bite::Email::Code.maketest(enginename, isexpected, true)
 

--- a/spec/sisimai/bite/email/private-postfix_spec.rb
+++ b/spec/sisimai/bite/email/private-postfix_spec.rb
@@ -222,6 +222,7 @@ isexpected = [
   { 'n' => '01218', 'r' => /blocked/ },
   { 'n' => '01219', 'r' => /suspend/ },
   { 'n' => '01220', 'r' => /virusdetected/ },
+  { 'n' => '01221', 'r' => /userunknown/ },
 ]
 Sisimai::Bite::Email::Code.maketest(enginename, isexpected, true)
 


### PR DESCRIPTION
- Bug fix in Sisimai::Bite::Email::MFILTER (Indicator string for detecting message/rfc822 part)
- Multibyte characters in the original subject will not be removed