### PR TITLE
v4.25.4p6

### DIFF
--- a/README-JA.md
+++ b/README-JA.md
@@ -19,7 +19,6 @@
 - [使い方 | Usage](#usage)
     - [基本的な使い方 | Basic usage](#basic-usage)
     - [解析結果をJSONで得る | Convert to JSON](#convert-to-json)
-    - [バウンスオブジェクトを読む | Read bounce object](#read-bounce-object)
     - [コールバック機能 | Callback feature](#callback-feature)
     - [ワンライナー | One-Liner](#one-liner)
     - [出力例 | Output example](#output-example)
@@ -56,8 +55,6 @@ Key features
   * 解析精度はbounceHammerの2倍
   * 29種類のMTAに対応
   * 22種類の著名なMSPに対応
-  * 2種類の著名なメール配信クラウドに対応(JSON)
-    * **Sisimai 4.25.5で削除予定**
   * Feedback Loopにも対応
   * 29種類のエラー理由を検出
 
@@ -158,30 +155,6 @@ puts Sisimai.dump('/path/to/mbox')  # or path to Maildir/
 # dump() method also accepts "delivered" option like the following code:
 puts Sisimai.dump('/path/to/mbox', delivered: true)
 ```
-
-Read bounce object
--------------------------------------------------------------------------------
-**この機能はSisimai 4.25.5で削除されます**
-
-メール配信クラウドからAPIで取得したバウンスオブジェクト(JSON)を読んで解析する
-場合は、次のようなコードを書いてください。この機能はSisimai v4.20.0で実装され
-ました。
-
-```ruby
-#! /usr/bin/env ruby
-require 'json'
-require 'sisimai'
-
-j = JSON.load('{"notificationType"=>"Bounce", "bounce"=>{"...') # JSON String
-v = Sisimai.make(j, input: 'json')
-
-if v.is_a? Array
-  v.each do |e|
-    ...
-  end
-end
-```
-現時点ではAmazon SESとSendGridのみをサポートしています。
 
 Callback feature
 -------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
 - [Usage](#usage)
     - [Basic usage](#basic-usage)
     - [Convert to JSON](#convert-to-json)
-    - [Read bounce object](#read-bounce-object)
     - [Callback feature](#callback-feature)
     - [One-Liner](#one-liner)
     - [Output example](#output-example)
@@ -55,8 +54,6 @@ Key Features
   * 2 times higher than bounceHammer
   * Support 24 known MTAs and 5 unknown MTAs
   * Support 22 major MSPs(Mail Service Providers)
-  * Support 2 major Cloud Email Delivery Services(JSON format)
-    * **WILL BE REMOVED AT Sisimai 4.25.5**
   * Support Feedback Loop Message(ARF)
   * Can detect 29 error reasons
 
@@ -163,30 +160,6 @@ puts Sisimai.dump('/path/to/mbox')  # or path to Maildir/
 # dump() method also accepts "delivered" option like the following code:
 puts Sisimai.dump('/path/to/mbox', delivered: true)
 ```
-
-Read bounce object
--------------------------------------------------------------------------------
-**THIS FEATURE WILL BE REMOVED AT SISIMAI 4.25.5**
-
-The way to read a bounce object retrived from Cloud Email Services as JSON using
-their API is the following code. This feature is available at between v4.20.0
-and **v4.25.5**.
-
-```ruby
-#! /usr/bin/env ruby
-require 'json'
-require 'sisimai'
-
-j = JSON.load('{"notificationType"=>"Bounce", "bounce"=>{"...') # JSON String
-v = Sisimai.make(j, input: 'json')
-
-if v.is_a? Array
-  v.each do |e|
-    ...
-  end
-end
-```
-As of present, Only Amazon SES and SendGrid are supported.
 
 Callback feature
 -------------------------------------------------------------------------------

--- a/lib/sisimai.rb
+++ b/lib/sisimai.rb
@@ -28,28 +28,25 @@ module Sisimai
       field = argv1[:field] || []
       raise ' ***error: "field" accepts an array only' unless field.is_a? Array
 
-      delivered1 = argv1[:delivered] || false
-      hookmethod = argv1[:hook] || nil
-      bouncedata = []
-
       require 'sisimai/data'
       require 'sisimai/message'
       require 'sisimai/mail'
 
+      list = []
       return nil unless mail = Sisimai::Mail.new(argv0)
       while r = mail.read do
         # Read and parse each mail file
-        methodargv = { data: r, hook: hookmethod, field: field }
+        methodargv = { data: r, hook: argv1[:hook], field: field }
         mesg = Sisimai::Message.new(methodargv)
         next if mesg.void
 
-        methodargv = { data: mesg, hook: hookmethod, delivered: delivered1 }
+        methodargv = { data: mesg, delivered: argv1[:delivered] }
         next unless data = Sisimai::Data.make(methodargv)
-        bouncedata += data unless data.empty?
+        list += data unless data.empty?
       end
 
-      return nil if bouncedata.empty?
-      return bouncedata
+      return nil if list.empty?
+      return list 
     end
 
     # Wrapper method to parse mailbox/Maildir and dump as JSON

--- a/lib/sisimai/address.rb
+++ b/lib/sisimai/address.rb
@@ -301,19 +301,15 @@ module Sisimai
       return cv[1] + '@' + local[1]
     end
 
-    @@roaccessors = [
-      :address, # [String] Email address
-      :user,    # [String] local part of the email address
-      :host,    # [String] domain part of the email address
-      :verp,    # [String] VERP
-      :alias,   # [String] alias of the email address
-    ]
-    @@rwaccessors = [
-      :name,    # [String] Display name
-      :comment, # [String] Comment
-    ]
-    @@roaccessors.each { |e| attr_reader   e }
-    @@rwaccessors.each { |e| attr_accessor e }
+    # :address, # [String] Email address
+    # :user,    # [String] local part of the email address
+    # :host,    # [String] domain part of the email address
+    # :verp,    # [String] VERP
+    # :alias,   # [String] alias of the email address
+    # :name,    # [String] Display name
+    # :comment, # [String] Comment
+    attr_reader   :address, :user, :host, :verp, :alias
+    attr_accessor :name, :comment
 
     # Constructor of Sisimai::Address
     # @param <str>  [String] argv1          Email address

--- a/lib/sisimai/address.rb
+++ b/lib/sisimai/address.rb
@@ -283,7 +283,7 @@ module Sisimai
     #   expand_verp('bounce+neko=example.org@example.org') #=> 'neko@example.org'
     def self.expand_verp(email)
       return nil unless email.is_a? Object::String
-      return nil unless cv = email.split('@', 2).first.match(/\A[-_\w]+?[+](\w[-._\w]+\w)[=](\w[-.\w]+\w)\z/)
+      return nil unless cv = email.split('@', 2).first.match(/\A[-\w]+?[+](\w[-.\w]+\w)[=](\w[-.\w]+\w)\z/)
       verp0 = cv[1] + '@' + cv[2]
       return verp0 if Sisimai::RFC5322.is_emailaddress(verp0)
     end
@@ -297,7 +297,7 @@ module Sisimai
       return nil unless Sisimai::RFC5322.is_emailaddress(email)
 
       local = email.split('@')
-      return nil unless cv = local[0].match(/\A([-_\w]+?)[+].+\z/)
+      return nil unless cv = local[0].match(/\A([-\w]+?)[+].+\z/)
       return cv[1] + '@' + local[1]
     end
 

--- a/lib/sisimai/data.rb
+++ b/lib/sisimai/data.rb
@@ -35,7 +35,7 @@ module Sisimai
       :deliverystatus,  # [String] Delivery Status(DSN)
       :timezoneoffset,  # [Integer] Time zone offset(seconds)
     ]
-    @@rwaccessors.each { |e| attr_accessor e }
+    attr_accessor(*@@rwaccessors)
 
     EndOfEmail = Sisimai::String.EOM
     RetryIndex = Sisimai::Reason.retry

--- a/lib/sisimai/data.rb
+++ b/lib/sisimai/data.rb
@@ -348,9 +348,8 @@ module Sisimai
             textasargv = (o.replycode + ' ' + p['diagnosticcode']).lstrip
             getchecked = Sisimai::SMTP::Error.is_permanent(textasargv)
             tmpfailure = getchecked.nil? ? false : (getchecked ? false : true)
-            pseudocode = Sisimai::SMTP::Status.code(o.reason, tmpfailure)
 
-            if pseudocode
+            if pseudocode = Sisimai::SMTP::Status.code(o.reason, tmpfailure)
               # Set the value of "deliverystatus" and "softbounce"
               o.deliverystatus = pseudocode
 

--- a/lib/sisimai/lhost.rb
+++ b/lib/sisimai/lhost.rb
@@ -81,20 +81,6 @@ module Sisimai
       #                                   part or nil if it failed to parse or
       #                                   the arguments are missing
       def make; return nil; end
-
-      # @abstract Print warnings about an obsoleted method. This method will be
-      #           removed at the future release of Sisimai
-      # @until    v4.25.5
-      def warn(whois = '', useit = nil)
-        label = ' ***warning:'
-        methodname = caller[0][/`.*'/][1..-2]
-        messageset = sprintf("%s %s.%s is marked as obsoleted", label, whois, methodname)
-
-        useit ||= methodname
-        messageset << sprintf(" and will be removed at %s.", removedat)
-        messageset << sprintf(" Use %s.%s instead.\n", self.name, useit) if useit != 'gone'
-        Kernel.warn messageset
-      end
     end
   end
 end

--- a/lib/sisimai/mail.rb
+++ b/lib/sisimai/mail.rb
@@ -3,15 +3,11 @@ module Sisimai
   # wrapper class of Sisimai::Mail::Mbox and Sisimai::Mail::Maildir classes.
   class Mail
     # Imported from p5-Sisimail/lib/Sisimai/Mail.pm
-    @@roaccessors = [
-      :path,  # [String] path to mbox or Maildir/
-      :type,  # [String] Data type: mailbox, maildir, or stdin
-    ]
-    @@rwaccessors = [
-      :mail,  # [Sisimai::Mail::[Mbox,Maildir,Memory,STDIN]] Object
-    ]
-    @@roaccessors.each { |e| attr_reader   e }
-    @@rwaccessors.each { |e| attr_accessor e }
+    # :path [String] path to mbox or Maildir/
+    # :type [String] Data type: mailbox, maildir, or stdin
+    # :mail [Sisimai::Mail::[Mbox,Maildir,Memory,STDIN]] Object
+    attr_reader   :path, :type
+    attr_accessor :mail
 
     # Constructor of Sisimai::Mail
     # @param    [String] argv1        Path to mbox or Maildir/

--- a/lib/sisimai/mail/maildir.rb
+++ b/lib/sisimai/mail/maildir.rb
@@ -4,19 +4,15 @@ module Sisimai
     # Maildir/ directory.
     class Maildir
       # Imported from p5-Sisimail/lib/Sisimai/Mail/Maildir.pm
-      @@roaccessors = [
-        :dir,     # [String] Path to Maildir/
-        :size,    # [Integer] The number of entires in the directory
-      ]
-      @@rwaccessors = [
-        :path,    # [String] Path to each file
-        :file,    # [String] Each file name of a mail in the Maildir/
-        :inodes,  # [Array]  i-node List of files in the Maildir/
-        :count,   # [Integer] The number of file has read
-        :handle,  # [IO::Dir] Directory handle
-      ]
-      @@roaccessors.each { |e| attr_reader   e }
-      @@rwaccessors.each { |e| attr_accessor e }
+      # :dir    [String] Path to Maildir/
+      # :size   [Integer] The number of entires in the directory
+      # :path   [String] Path to each file
+      # :file,  [String] Each file name of a mail in the Maildir/
+      # :inodes [Array]  i-node List of files in the Maildir/
+      # :count  [Integer] The number of file has read
+      # :handle [IO::Dir] Directory handle
+      attr_reader :dir, :size
+      attr_accessor :path, :file, :inodes, :count, :handle
 
       # Constructor of Sisimai::Mail::Maildir
       # @param    [String] argvs                Path to Maildir/

--- a/lib/sisimai/mail/mbox.rb
+++ b/lib/sisimai/mail/mbox.rb
@@ -3,18 +3,14 @@ module Sisimai
     # Sisimai::Mail::Mbox is a mailbox file (UNIX mbox) reader.
     class Mbox
       # Imported from p5-Sisimail/lib/Sisimai/Mail/Mbox.pm
-      @@roaccessors = [
-        :dir,     # [String]  Directory name of the mbox
-        :file,    # [String]  File name of the mbox
-        :path,    # [String]  Path to mbox
-        :size,    # [Integer] File size of the mbox
-      ]
-      @@rwaccessors = [
-        :offset,  # [Integer]  Offset position for seeking
-        :handle,  # [IO::File] File handle
-      ]
-      @@roaccessors.each { |e| attr_reader   e }
-      @@rwaccessors.each { |e| attr_accessor e }
+      # :dir    [String]  Directory name of the mbox
+      # :file   [String]  File name of the mbox
+      # :path   [String]  Path to mbox
+      # :size   [Integer] File size of the mbox
+      # :offset [Integer]  Offset position for seeking
+      # :handle [IO::File] File handle
+      attr_reader :dir, :file, :path, :size
+      attr_accessor :offset, :handle
 
       # Constructor of Sisimai::Mail::Mbox
       # @param    [String] argv1            Path to mbox

--- a/lib/sisimai/mail/memory.rb
+++ b/lib/sisimai/mail/memory.rb
@@ -3,15 +3,11 @@ module Sisimai
     # Sisimai::Mail::Memory is a class for reading an email string
     class Memory
       # Imported from p5-Sisimail/lib/Sisimai/Mail/Memory.pm
-      @@roaccessors = [
-        :size,    # [Integer] data size of the email text
-      ]
-      @@rwaccessors = [
-        :data,    # [Array]   Entire bounce mail message
-        :offset,  # [Integer] Index of ":data"
-      ]
-      @@roaccessors.each { |e| attr_reader   e }
-      @@rwaccessors.each { |e| attr_accessor e }
+      # :size   [Integer] data size of the email text
+      # :data   [Array]   Entire bounce mail message
+      # :offset [Integer] Index of ":data"
+      attr_reader :size
+      attr_accessor :data, :offset
 
       # Constructor of Sisimai::Mail::Memory
       # @param    [String] argv1              Entire email string

--- a/lib/sisimai/mail/stdin.rb
+++ b/lib/sisimai/mail/stdin.rb
@@ -4,17 +4,13 @@ module Sisimai
     # STDIN
     class STDIN
       # Imported from p5-Sisimail/lib/Sisimai/Mail/STDIN.pm
-      @@roaccessors = [
-        :path,    # [String]  Path to mbox
-        :name,    # [String]  File name of the mbox
-        :size,    # [Integer] File size of the mbox
-      ]
-      @@rwaccessors = [
-        :offset,  # [Integer]  Offset position for seeking
-        :handle,  # [IO::File] File handle
-      ]
-      @@roaccessors.each { |e| attr_reader   e }
-      @@rwaccessors.each { |e| attr_accessor e }
+      # :path   [String]  Path to mbox
+      # :name   [String]  File name of the mbox
+      # :size   [Integer] File size of the mbox
+      # :offset [Integer]  Offset position for seeking
+      # :handle [IO::File] File handle
+      attr_reader :path, :name, :size
+      attr_accessor :offset, :handle
 
       # Constructor of Sisimai::Mail::STDIN
       # @param    [IO::STDIN] stdin      Standard-In

--- a/lib/sisimai/message.rb
+++ b/lib/sisimai/message.rb
@@ -54,7 +54,7 @@ module Sisimai
         return nil
       end
 
-      methodargv = { 'data'  => email, 'hook' => argvs[:hook] || nil, 'field' => field }
+      methodargv = { 'data' => email, 'hook' => argvs[:hook] || nil, 'field' => field }
       [:load, :order].each do |e|
         # Order of MTA modules
         next unless argvs.key?(e)

--- a/lib/sisimai/message.rb
+++ b/lib/sisimai/message.rb
@@ -521,20 +521,6 @@ module Sisimai
       return parseddata
     end
 
-    # @abstract Print warnings about an obsoleted method. This method will be
-    #           removed at the future release of Sisimai
-    # @until    v4.25.5
-    def self.warn(whois = '', useit = nil)
-      label = ' ***warning:'
-      methodname = caller[0][/`.*'/][1..-2]
-      messageset = sprintf("%s %s.%s is marked as obsoleted", label, whois, methodname)
-
-      useit ||= methodname
-      messageset << sprintf(" and will be removed at %s.", Sisimai::Lhost.removedat)
-      messageset << sprintf(" Use %s.%s instead.\n", self.name, useit) if useit != 'gone'
-      Kernel.warn messageset
-    end
-
   end
 end
 

--- a/lib/sisimai/message.rb
+++ b/lib/sisimai/message.rb
@@ -5,6 +5,13 @@ module Sisimai
   # method is not a bounce email, the method returns nil.
   class Message
     # Imported from p5-Sisimail/lib/Sisimai/Message.pm
+    # :from   [String] UNIX From line
+    # :header [Hash]   Header part of an email
+    # :ds     [Array]  Parsed data by Sisimai::Lhost::* module
+    # :rfc822 [Hash]   Header part of the original message
+    # :catch  [Any]    The results returned by hook method
+    attr_accessor :from, :header, :ds, :rfc822, :catch
+
     require 'sisimai/arf'
     require 'sisimai/mime'
     require 'sisimai/order'
@@ -13,15 +20,6 @@ module Sisimai
     require 'sisimai/rfc5322'
     require 'sisimai/rfc3834'
     require 'sisimai/smtp/error'
-
-    @@rwaccessors = [
-      :from,    # [String] UNIX From line
-      :header,  # [Hash]   Header part of an email
-      :ds,      # [Array]  Parsed data by Sisimai::Lhost::* module
-      :rfc822,  # [Hash]   Header part of the original message
-      :catch,   # [Any]      The results returned by hook method
-    ]
-    @@rwaccessors.each { |e| attr_accessor e }
 
     DefaultSet = Sisimai::Order.another
     ExtHeaders = Sisimai::Order.headers

--- a/lib/sisimai/order.rb
+++ b/lib/sisimai/order.rb
@@ -218,20 +218,6 @@ module Sisimai
         return table
       end
 
-      # @abstract Print warnings about an obsoleted method. This method will be
-      #           removed at the future release of Sisimai
-      # @until    v4.25.6
-      def warn(whois = '', useit = nil)
-        label = ' ***warning:'
-        methodname = caller[0][/`.*'/][1..-2]
-        messageset = sprintf("%s %s.%s is marked as obsoleted", label, whois, methodname)
-
-        useit ||= methodname
-        messageset << sprintf(" and will be removed at %s.", Sisimai::Lhost.removedat)
-        messageset << sprintf(" Use %s.%s instead.\n", self.name, useit) if useit != 'gone'
-        Kernel.warn messageset
-      end
-
     end
   end
 end

--- a/lib/sisimai/reason.rb
+++ b/lib/sisimai/reason.rb
@@ -57,11 +57,9 @@ module Sisimai
           # regular expression of retry() method.
           return argvs.reason unless argvs.reason.empty?
         end
+        return 'delivered' if argvs.deliverystatus.start_with?('2.')
 
-        statuscode = argvs.deliverystatus || ''
         reasontext = ''
-        return 'delivered' if statuscode.start_with?('2.')
-
         if argvs.diagnostictype == 'SMTP' || argvs.diagnostictype == ''
           # Diagnostic-Code: SMTP; ... or empty value
           ClassOrder[0].each do |e|

--- a/lib/sisimai/version.rb
+++ b/lib/sisimai/version.rb
@@ -1,4 +1,4 @@
 # Define the version number of Sisimai
 module Sisimai
-  VERSION = '4.25.4p5'.freeze
+  VERSION = '4.25.4p6'.freeze
 end


### PR DESCRIPTION
- Remove the ability for parsing JSON as a bounce object
- Accessor improvement in the following classes:
  - `Sisimai::Message`
  - `Sisimai::Data`
  - `Sisimai::Address`
  - `Sisimai::Mail` and children
- Tiny code and variable improvement
- Remove `warn()` method from `Sisimai::Message`, `Sisimai::Order`, and `Sisimai::Lhost`