### PR TITLE
Remove field param

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,12 @@ v4.25.5p9
     - The MTA module to be loaded at first is decided by the first 2 words of
       each bounce mail subject, is defined at `Subject` in `Sisimai::Order`
     - Some variables are replaced with `state`
+  - Each `field` parameter has been removed from the following methods because 
+    Sisimai detect all the email header fields by `Sisimai::Message.makemap()`
+    without having to specify field names at `field` parameter
+    - `Sisimai.make`
+    - `Sisimai::Message.new`
+    - `Sisimai::Message.make`
   - Code improvement for `require` statement before calling `match()` method of
     some modules defined in `$PreMatches` at `Sisimai::Reason::UserUnknown`
   - Remove the following unused methods:

--- a/README-JA.md
+++ b/README-JA.md
@@ -175,9 +175,8 @@ callbackto = lambda do |v|
   return r
 end
 
-list = ['X-Mailer']
-data = Sisimai.make('/path/to/mbox', hook: callbackto, field: list)
-json = Sisimai.dump('/path/to/mbox', hook: callbackto, field: list)
+data = Sisimai.make('/path/to/mbox', hook: callbackto)
+json = Sisimai.dump('/path/to/mbox', hook: callbackto)
 
 puts data[0].catch['x-mailer']      # Apple Mail (2.1283)
 ```

--- a/README.md
+++ b/README.md
@@ -179,9 +179,8 @@ callbackto = lambda do |v|
   return r
 end
 
-list = ['X-Mailer']
-data = Sisimai.make('/path/to/mbox', hook: callbackto, field: list)
-json = Sisimai.dump('/path/to/mbox', hook: callbackto, field: list)
+data = Sisimai.make('/path/to/mbox', hook: callbackto)
+json = Sisimai.dump('/path/to/mbox', hook: callbackto)
 
 puts data[0].catch['x-mailer']      # Apple Mail (2.1283)
 ```

--- a/lib/sisimai.rb
+++ b/lib/sisimai.rb
@@ -19,15 +19,10 @@ module Sisimai
     # @param         [Hash]   argv1      Parser options(delivered=false)
     # @options argv1 [Boolean] delivered true: Include "delivered" reason
     # @options argv1 [Lambda]  hook      Lambda object to be called back
-    # @options argv1 [Array]   field     Email header name to be captured
     # @return        [Array]             Parsed objects
     # @return        [nil]               nil if the argument was wrong or an empty array
     def make(argv0, **argv1)
       return nil unless argv0
-
-      field = argv1[:field] || []
-      raise ' ***error: "field" accepts an array only' unless field.is_a? Array
-
       require 'sisimai/data'
       require 'sisimai/message'
       require 'sisimai/mail'
@@ -36,7 +31,7 @@ module Sisimai
       return nil unless mail = Sisimai::Mail.new(argv0)
       while r = mail.read do
         # Read and parse each mail file
-        methodargv = { data: r, hook: argv1[:hook], field: field }
+        methodargv = { data: r, hook: argv1[:hook] }
         mesg = Sisimai::Message.new(methodargv)
         next if mesg.void
 

--- a/lib/sisimai/message.rb
+++ b/lib/sisimai/message.rb
@@ -26,24 +26,15 @@ module Sisimai
     # @param         [Hash] argvs       Module to be loaded
     # @options argvs [String] :data     Entire email message
     # @options argvs [Array]  :load     User defined MTA module list
-    # @options argvs [Array]  :field    Email header names to be captured
     # @options argvs [Array]  :order    The order of MTA modules
     # @options argvs [Code]   :hook     Reference to callback method
     # @return        [Sisimai::Message] Structured email data or nil if each
     #                                   value of the arguments are missing
     def initialize(data: '', **argvs)
       return nil if data.empty?
-
       email = data.scrub('?').gsub("\r\n", "\n")
-      field = argvs[:field] || []
 
-      unless field.is_a? Array
-        # Unsupported value in "field"
-        warn ' ***warning: "field" accepts an array reference only'
-        return nil
-      end
-
-      methodargv = { 'data' => email, 'hook' => argvs[:hook] || nil, 'field' => field }
+      methodargv = { 'data' => email, 'hook' => argvs[:hook] || nil }
       [:load, :order].each do |e|
         # Order of MTA modules
         next unless argvs[e]
@@ -74,7 +65,6 @@ module Sisimai
     # @param         [Hash] argvs   Email data
     # @options argvs [String] data  Entire email message
     # @options argvs [Array]  load  User defined MTA module list
-    # @options argvs [Array]  field Email header names to be captured
     # @options argvs [Array]  order The order of MTA modules
     # @options argvs [Code]   hook  Reference to callback method
     # @return        [Hash]         Resolved data structure

--- a/spec/sisimai_spec.rb
+++ b/spec/sisimai_spec.rb
@@ -147,10 +147,8 @@ describe Sisimai do
           data['x-virus-scanned'] = argv['headers']['x-virus-scanned'] || ''
           return data
         end
-        havecaught = Sisimai.make(sampleemail[e],
-                                  hook: callbackto,
-                                  field: ['X-Virus-Scanned'])
 
+        havecaught = Sisimai.make(sampleemail[e], hook: callbackto)
         havecaught.each do |ee|
           it('is Sisimai::Data') { expect(ee).to be_a Sisimai::Data }
           it('is Hash') { expect(ee.catch).to be_a Hash }
@@ -209,12 +207,6 @@ describe Sisimai do
       it 'raises ArgumentError' do
         expect { Sisimai.make }.to raise_error(ArgumentError)
         expect { Sisimai.make(nil, nil) }.to raise_error(ArgumentError)
-      end
-    end
-
-    context 'Invalid value in arguments' do
-      it 'raises RuntimeError' do
-        expect { Sisimai.make('/dev/null', field: 'neko') }.to raise_error(RuntimeError)
       end
     end
   end


### PR DESCRIPTION
- Each `field` parameter has been removed from the following methods because  Sisimai detect all the email header fields by `Sisimai::Message.makemap()` without having to specify field names at `field` parameter
    - `Sisimai.make`
    - `Sisimai::Message.new`
    - `Sisimai::Message.make`
