### PR TITLE
New accessor "origin" in Sisimai::Data object

### DIFF
--- a/lib/sisimai.rb
+++ b/lib/sisimai.rb
@@ -35,7 +35,7 @@ module Sisimai
         mesg = Sisimai::Message.new(methodargv)
         next if mesg.void
 
-        methodargv = { data: mesg, delivered: argv1[:delivered] }
+        methodargv = { data: mesg, delivered: argv1[:delivered], origin: mail.mail.path }
         next unless data = Sisimai::Data.make(methodargv)
         list += data unless data.empty?
       end

--- a/lib/sisimai/data.rb
+++ b/lib/sisimai/data.rb
@@ -19,6 +19,7 @@ module Sisimai
       :listid,          # [String] List-Id header of each ML
       :reason,          # [String] Bounce reason
       :action,          # [String] The value of Action: header
+      :origin,          # [String] Email path as a data source
       :subject,         # [String] UTF-8 Subject text
       :timestamp,       # [Sisimai::Time] Date: header in the original message
       :addresser,       # [Sisimai::Address] From address
@@ -77,6 +78,7 @@ module Sisimai
       @smtpcommand    = argvs['smtpcommand']    || ''
       @feedbacktype   = argvs['feedbacktype']   || ''
       @action         = argvs['action']         || ''
+      @origin         = argvs['origin']         || ''
       @replycode      = argvs['replycode']      || ''
       @replycode      = Sisimai::SMTP::Reply.find(argvs['diagnosticcode']).to_s if @replycode.empty?
       @softbounce     = argvs['softbounce']     || ''
@@ -293,6 +295,7 @@ module Sisimai
 
         # Check the value of SMTP command
         p['smtpcommand'] = '' unless %w[EHLO HELO MAIL RCPT DATA QUIT].include?(p['smtpcommand'])
+        p['origin'] = argvs[:origin]  # Set the path to the original email
 
         if p['action'].empty?
           # Check the value of "action"

--- a/lib/sisimai/mail/memory.rb
+++ b/lib/sisimai/mail/memory.rb
@@ -3,10 +3,11 @@ module Sisimai
     # Sisimai::Mail::Memory is a class for reading an email string
     class Memory
       # Imported from p5-Sisimail/lib/Sisimai/Mail/Memory.pm
+      # :path   [String]  Fixed string "<MEMORY>"
       # :size   [Integer] data size of the email text
       # :data   [Array]   Entire bounce mail message
       # :offset [Integer] Index of ":data"
-      attr_reader :size
+      attr_reader :path, :size
       attr_accessor :data, :offset
 
       # Constructor of Sisimai::Mail::Memory
@@ -17,6 +18,7 @@ module Sisimai
         raise 'is not a String' unless argv1.is_a? ::String
         raise 'is empty'        if argv1.empty?
 
+        @path   = '<MEMORY>'
         @size   = argv1.size
         @data   = []
         @offset = 0

--- a/lib/sisimai/mail/stdin.rb
+++ b/lib/sisimai/mail/stdin.rb
@@ -4,7 +4,7 @@ module Sisimai
     # STDIN
     class STDIN
       # Imported from p5-Sisimail/lib/Sisimai/Mail/STDIN.pm
-      # :path   [String]  Path to mbox
+      # :path   [String]  Fixed string "<STDIN>"
       # :name   [String]  File name of the mbox
       # :size   [Integer] File size of the mbox
       # :offset [Integer]  Offset position for seeking

--- a/spec/sisimai/data/json_spec.rb
+++ b/spec/sisimai/data/json_spec.rb
@@ -16,7 +16,7 @@ describe Sisimai::Data::JSON do
 
   while r = mail.read do
     mesg = Sisimai::Message.new(data: r)
-    data = Sisimai::Data.make(data: mesg)
+    data = Sisimai::Data.make(data: mesg, origin: mail.mail.path)
     it('returns Array') { expect(data).to be_a Array }
 
     describe '#dump' do

--- a/spec/sisimai/data/yaml_spec.rb
+++ b/spec/sisimai/data/yaml_spec.rb
@@ -16,7 +16,7 @@ describe Sisimai::Data::YAML do
 
   while r = mail.read do
     mesg = Sisimai::Message.new(data: r)
-    data = Sisimai::Data.make(data: mesg)
+    data = Sisimai::Data.make(data: mesg, origin: mail.mail.path)
     it('returns Array') { expect(data).to be_a Array }
 
     describe '#dump' do

--- a/spec/sisimai/data_spec.rb
+++ b/spec/sisimai/data_spec.rb
@@ -21,7 +21,7 @@ describe Sisimai::Data do
 
     while r = mail.read do
       mesg = Sisimai::Message.new(data: r, hook: call)
-      data = Sisimai::Data.make(data: mesg)
+      data = Sisimai::Data.make(data: mesg, origin: mail.mail.path)
       example 'Sisimai::Data.make returns Array' do
         expect(data).to be_a Array
       end
@@ -116,6 +116,9 @@ describe Sisimai::Data do
 
         example('#feedbacktype is String') { expect(e.feedbacktype).to be_a String }
         example('#feedbacktype is empty') { expect(e.feedbacktype).to be_empty }
+
+        example('#origin is String') { expect(e.origin).to be_a String }
+        example('#origin is a path') { expect(e.origin).to match(%r|/.+[.]eml|) }
 
         example('#catch is Hash') { expect(e.catch).to be_a Hash }
         example('#catch[type] is "email"') { expect(e.catch['type']).to be == 'email' }

--- a/spec/sisimai/lhost/code.rb
+++ b/spec/sisimai/lhost/code.rb
@@ -206,7 +206,7 @@ module Sisimai
                     end # End of Sisimai::Message#ds
                   end # End of Sisimai::Message
 
-                  dataobject = Sisimai::Data.make(data: mesgobject, delivered: true)
+                  dataobject = Sisimai::Data.make(data: mesgobject, delivered: true, origin: mailobject.mail.path)
                   describe Sisimai::Data do
                     next unless dataobject
                     next if dataobject.empty?
@@ -303,7 +303,7 @@ module Sisimai
                         expect(pr.alias).not_to match /[\r]/
                       end
 
-                      %w|smtpcommand lhost rhost alias listid action messageid|.each do |pp|
+                      %w|smtpcommand lhost rhost alias listid action messageid origin|.each do |pp|
                         if pp == 'alias'
                           it sprintf("%s #%s does not include %s", lb, pp, '\r') do
                             expect(pr.send(pp)).not_to match(/[\r]/)

--- a/spec/sisimai/mail/memory_spec.rb
+++ b/spec/sisimai/mail/memory_spec.rb
@@ -55,6 +55,13 @@ describe Sisimai::Mail::Memory do
       before do
         mailobj.read
       end
+      describe '#path' do
+        subject { mailobj.path }
+        it 'is "<MEMORY>"' do
+          is_expected.to be_a ::String
+          is_expected.to be == '<MEMORY>'
+        end
+      end
       describe '#size' do
         subject { mailobj.size }
         it 'returns email size' do

--- a/spec/sisimai_spec.rb
+++ b/spec/sisimai_spec.rb
@@ -214,7 +214,7 @@ describe Sisimai do
   describe '.dump' do
     tobetested = %w|
       addresser recipient senderdomain destination reason timestamp 
-      token smtpagent
+      token smtpagent origin
     |
 
     context 'valid email file' do


### PR DESCRIPTION
- Import https://github.com/sisimai/p5-Sisimai/pull/383
- Add `path` accessor at `Sisimai::Mail::Memory`
  - returns the fixed string `<MEMORY>`
- Add `origin` accessor at `Sisimai::Data`
  - `Sisimai::Data->origin` returns the path to the original email file of the parsed results
  - `Sisimai::Data->make` receives `origin` key and its value as an arguments
- For example, the parsed results of `set-of-emails/maildir/bsd/lhost-barracuda-*.eml` are the following JSON formatted data:

```json
[
  {
    "origin": "set-of-emails/maildir/bsd/lhost-barracuda-01.eml",
    "subject": "Nyaan",
    "diagnostictype": "SMTP",
    "timestamp": 1177889685,
    "softbounce": 1,
    "action": "failed",
    "replycode": "550",
    "deliverystatus": "5.7.1",
    "messageid": "ad4be1052982bf7aa5558be760abbf74@neko.example.com",
    "token": "97efb3278821c5eac776066a7f56f1cad123d31d",
    "destination": "example.org",
    "catch": {
      "queie-id": "",
      "sender": "",
      "x-mailer": ""
    },
    "listid": "",
    "diagnosticcode": "550 5.7.1 Message content rejected, UBE, id=00000-22-225",
    "timezoneoffset": "+0900",
    "senderdomain": "example.org",
    "recipient": "kijitora@example.org",
    "rhost": "barracuda.cat.example.jp",
    "lhost": "barracuda.cat.example.jp",
    "feedbacktype": "",
    "reason": "spamdetected",
    "smtpagent": "Barracuda",
    "smtpcommand": "",
    "addresser": "neko@example.org",
    "alias": ""
  },
  {
    "smtpagent": "Barracuda",
    "feedbacktype": "",
    "reason": "spamdetected",
    "alias": "",
    "addresser": "neko-nyaan@example.jp",
    "smtpcommand": "",
    "timezoneoffset": "+0000",
    "senderdomain": "example.jp",
    "diagnosticcode": "550 5.7.1 Message content rejected, UBE, id=22220-02-222",
    "listid": "",
    "lhost": "mail.neko.example.org",
    "rhost": "mail.neko.example.org",
    "recipient": "kijitora@example.jp",
    "destination": "example.jp",
    "token": "08f99ccce01ad9058b6b4c743d7380e5413cf015",
    "messageid": "201104292334545.62412C6FD0F1@email-4.example.jp",
    "catch": {
      "sender": "",
      "queie-id": "",
      "x-mailer": ""
    },
    "replycode": "550",
    "action": "failed",
    "softbounce": 1,
    "timestamp": 1304152485,
    "diagnostictype": "SMTP",
    "subject": "Nenko Nyaan",
    "origin": "set-of-emails/maildir/bsd/lhost-barracuda-02.eml",
    "deliverystatus": "5.7.1"
  }
]
```