### PR TITLE
Remove old parameters at the callback feature

### DIFF
--- a/lib/sisimai/message.rb
+++ b/lib/sisimai/message.rb
@@ -276,12 +276,7 @@ module Sisimai
       if hookmethod.is_a? Proc
         # Call the hook method
         begin
-          p = {
-            'datasrc' => 'email',
-            'headers' => mailheader,
-            'message' => bodystring,
-            'bounces' => nil
-          }
+          p = { 'headers' => mailheader, 'message' => bodystring }
           havecaught = hookmethod.call(p)
         rescue StandardError => ce
           warn ' ***warning: Something is wrong in hook method :' << ce.to_s

--- a/spec/sisimai/data_spec.rb
+++ b/spec/sisimai/data_spec.rb
@@ -7,7 +7,7 @@ describe Sisimai::Data do
   context 'without orders of email address headers' do
     mail = Sisimai::Mail.new('./set-of-emails/maildir/bsd/lhost-sendmail-03.eml')
     call = lambda do |argv|
-      data = { 'x-mailer' => '', 'return-path' => '', 'type' => argv['datasrc'] }
+      data = { 'x-mailer' => '', 'return-path' => '' }
       if cv = argv['message'].match(/^X-Mailer:\s*(.+)$/)
           data['x-mailer'] = cv[1]
       end
@@ -121,7 +121,6 @@ describe Sisimai::Data do
         example('#origin is a path') { expect(e.origin).to match(%r|/.+[.]eml|) }
 
         example('#catch is Hash') { expect(e.catch).to be_a Hash }
-        example('#catch[type] is "email"') { expect(e.catch['type']).to be == 'email' }
         example('#catch[x-mailer] is String') { expect(e.catch['x-mailer']).to be_a String }
         example('#catch[x-mailer] includes "Apple"') { expect(e.catch['x-mailer']).to match(/Apple/) }
         example('#catch[return-path] is String') { expect(e.catch['return-path']).to be_a String }

--- a/spec/sisimai/message_spec.rb
+++ b/spec/sisimai/message_spec.rb
@@ -7,7 +7,7 @@ describe Sisimai::Message do
 
   mailstring = File.open(sf).read
   callbackto = lambda do |argv|
-    data = { 'x-mailer' => '', 'return-path' => '', 'type' => argv['datasrc'] }
+    data = { 'x-mailer' => '', 'return-path' => '' }
     if cv = argv['message'].match(/^X-Mailer:\s*(.+)$/)
         data['x-mailer'] = cv[1]
     end
@@ -84,7 +84,6 @@ describe Sisimai::Message do
   end
 
   describe '#catch' do
-    example('type is "email"') { expect(messageobj.catch['type']).to be == 'email' }
     %w|return-path x-mailer from|.each do |e|
       example(e + 'key exists') { expect(messageobj.catch.key?(e)).to be true }
     end

--- a/spec/sisimai_spec.rb
+++ b/spec/sisimai_spec.rb
@@ -133,7 +133,6 @@ describe Sisimai do
           data = {
             'x-mailer' => '',
             'return-path' => '',
-            'type' => argv['datasrc'],
             'x-virus-scanned' => '',
           }
           if cv = argv['message'].match(/^X-Mailer:\s*(.+)$/)
@@ -152,7 +151,6 @@ describe Sisimai do
         havecaught.each do |ee|
           it('is Sisimai::Data') { expect(ee).to be_a Sisimai::Data }
           it('is Hash') { expect(ee.catch).to be_a Hash }
-          it('"type" is "email"') { expect(ee.catch['type']).to be == 'email' }
           it('exists "x-mailer" key') { expect(ee.catch.key?('x-mailer')).to be true }
 
           if ee.catch['x-mailer'].size > 0


### PR DESCRIPTION
Remove the following parameters at the callback feature:
- `datasrc`: Beginning from v4.25.5, input data source at the callback feature is only `email` 
- `bounces`: JSON format as an input data source is no longer available at v4.25.5 or later