### PR TITLE
Suppress keyword argument warnings in Ruby 2.7

### DIFF
--- a/lib/sisimai.rb
+++ b/lib/sisimai.rb
@@ -31,11 +31,11 @@ module Sisimai
       while r = mail.data.read do
         # Read and parse each email file
         methodargv = { data: r, hook: argv1[:hook] }
-        mesg = Sisimai::Message.new(methodargv)
+        mesg = Sisimai::Message.new(**methodargv)
         next if mesg.void
 
         methodargv = { data: mesg, delivered: argv1[:delivered], origin: mail.data.path }
-        next unless data = Sisimai::Data.make(methodargv)
+        next unless data = Sisimai::Data.make(**methodargv)
         list += data unless data.empty?
       end
 
@@ -54,7 +54,7 @@ module Sisimai
     def dump(argv0, **argv1)
       return nil unless argv0
 
-      nyaan = Sisimai.make(argv0, argv1) || []
+      nyaan = Sisimai.make(argv0, **argv1) || []
       if RUBY_PLATFORM.start_with?('java')
         # java-based ruby environment like JRuby.
         require 'jrjackson'


### PR DESCRIPTION
This PR suppresses the following keyword argument warnings when using Ruby 2.7.

```console
% ruby -v
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-darwin17]
% cd path/to/sisimai/rb-Sisimai
% bundle exec rake
(snip)

/lib/ruby/gems/2.7.0/gems/rspec-support-3.9.3/lib
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-core-3.9.2/exe/rspec
--pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
/Users/koic/src/github.com/sisimai/rb-Sisimai/lib/sisimai.rb:34:
warning: Using the last argument as keyword parameters is deprecated;
maybe ** should be added to the call
/Users/koic/src/github.com/sisimai/rb-Sisimai/lib/sisimai/message.rb:33:
warning: The called method `initialize' is defined here
/Users/koic/src/github.com/sisimai/rb-Sisimai/lib/sisimai.rb:38:
warning: Using the last argument as keyword parameters is deprecated;
maybe ** should be added to the call
/Users/koic/src/github.com/sisimai/rb-Sisimai/lib/sisimai/data.rb:92:
warning: The called method `make' is defined here
/Users/koic/src/github.com/sisimai/rb-Sisimai/lib/sisimai.rb:57:
warning: Using the last argument as keyword parameters is deprecated;
maybe ** should be added to the call
/Users/koic/src/github.com/sisimai/rb-Sisimai/lib/sisimai.rb:23:
warning: The called method `make' is defined here
```

cf: https://bugs.ruby-lang.org/issues/14183