### PR TITLE
Suppress a Ruby warning for `Object#=~`

### DIFF
--- a/lib/sisimai/lhost/ezweb.rb
+++ b/lib/sisimai/lhost/ezweb.rb
@@ -125,7 +125,7 @@ module Sisimai::Lhost
               v['command'] = cv[1]
             else
               # Check error message
-              if rxmessages.any? { |a| e =~ a }
+              if rxmessages.any? { |messages| messages.any? { |message| e =~ message } }
                 # Check with regular expressions of each error
                 v['diagnosis'] ||= ''
                 v['diagnosis'] << ' ' << e


### PR DESCRIPTION
THis PR suppresses the following a Ruby warning for `Object#=~`.

```console
% ruby -v
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-darwin17]

% cd path/to/sisimai/rb-Sisimai
% bundle exec rake
(snip)

/Users/koic/src/github.com/sisimai/rb-Sisimai/lib/sisimai/lhost/ezweb.rb:128:
warning: deprecated Object#=~ is called on Array; it always returns nil
```

I think it would be expected to be compared to a message, not to an array of messages.

cf: https://bugs.ruby-lang.org/issues/15231