### PR TITLE
Issue 224 invalid byte sequence in utf8

### DIFF
--- a/lib/sisimai/mime.rb
+++ b/lib/sisimai/mime.rb
@@ -225,7 +225,7 @@ module Sisimai
 
         plain = nil
         if cv = argv1.match(%r|([+/\=0-9A-Za-z\r\n]+)|) then plain = Base64.decode64(cv[1]) end
-        return plain.force_encoding('UTF-8')
+        return plain.scrub('?')
       end
 
       # Get boundary string

--- a/set-of-emails/maildir/bsd/rfc3464-42.eml
+++ b/set-of-emails/maildir/bsd/rfc3464-42.eml
@@ -1,0 +1,34 @@
+From MAILER-DAEMON  Mon Sep 20 19:33:02 2021
+Return-Path: <>
+X-Original-To: postmaster@blackhole.our-host.net
+Delivered-To: blackhole@localhost
+Received: from mx2.itnetwork.net (mx2.itnetwork.net [123.123.123.202])
+	by play.thmthlayer.com (Postfix) with ESMTPS id 94598E117B
+	for <postmaster@blackhole.our-host.net>; Mon, 20 Sep 2021 19:33:02 +0000 (UTC)
+Received: from 10.9.37.234 ([10.9.34.13]) by mx2.itnetwork.net with ESMTP id rTR3cr9xLoMiR5vX for <postmaster@blackhole.our-host.net>; Mon, 20 Sep 2021 21:33:01 +0200 (CEST)
+Date: Mon, 20 Sep 2021 21:32:59 +0200 (GMT+02:00)
+From: Postmaster@bit-onbreeeck.org
+To: MyName <message@gelaneeiuet.org>
+Subject: foobar
+Mime-Version: 1.0
+Message-ID: <OFB3228DED.DDDCAC8E-ONC1258756.006B648D-C1258756.006B6493@bit-onbreeeck.org>
+Content-Type: multipart/report; report-type=delivery-status; boundary="==IFJRGLKFGIR7891042UHRUHIHD"
+
+--==IFJRGLKFGIR7891042UHRUHIHD
+Content-Type: text/plain; charset=ISO-8859-1
+Content-Transfer-Encoding: base64
+
+ICBhdWZnZWb8aHJ0DQoNCg==
+
+--==IFJRGLKFGIR7891042UHRUHIHD
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns;10.9.37.234
+
+Final-Recipient: rfc822;jane.doe@some-domain.net
+Action: failed
+Status: 5.0.0
+Diagnostic-Code: The email account that you tried to reach does not exist.
+
+--==IFJRGLKFGIR7891042UHRUHIHD--
+

--- a/spec/sisimai/lhost/public-rfc3464_spec.rb
+++ b/spec/sisimai/lhost/public-rfc3464_spec.rb
@@ -21,5 +21,6 @@ isexpected = [
   { 'n' => '39', 's' => /\A5[.]0[.]\d+\z/,   'r' => /onhold/,      'a' => /RFC3464/, 'b' => /\A1\z/ },
   { 'n' => '40', 's' => /\A4[.]4[.]6\z/,     'r' => /networkerror/,'a' => /RFC3464/, 'b' => /\A1\z/ },
   { 'n' => '41', 's' => /\A5[.]0[.]901\z/,   'r' => /onhold/,      'a' => /RFC3464/, 'b' => /\A1\z/ },
+  { 'n' => '42', 's' => /\A5[.]0[.]0\z/,     'r' => /filtered/,    'a' => /RFC3464/, 'b' => /\A1\z/ },
 ]
 Sisimai::Lhost::Code.maketest(enginename, isexpected)

--- a/spec/sisimai/mail/maildir_spec.rb
+++ b/spec/sisimai/mail/maildir_spec.rb
@@ -3,7 +3,7 @@ require 'sisimai/mail/maildir'
 
 describe Sisimai::Mail::Maildir do
   samplemaildir = './set-of-emails/maildir/bsd'
-  allofthefiles = 506
+  allofthefiles = 507
   let(:mailobj) { Sisimai::Mail::Maildir.new(samples) }
   let(:mockobj) { Sisimai::Mail::Maildir.new(invalid) }
 

--- a/spec/sisimai/mime_spec.rb
+++ b/spec/sisimai/mime_spec.rb
@@ -140,7 +140,7 @@ Arrival-Date: Tue, 23 Dec 2014 20:39:34 +0000
     context 'Base64 string' do
       b8 = '44Gr44KD44O844KT'
       p8 = 'にゃーん'
-      it('returns ' + p8) { expect(cn.base64d(b8)).to be == p8 }
+      it('returns ' + p8) { expect(cn.base64d(b8).force_encoding('UTF-8')).to be == p8 }
     end
     context 'wrong number of arguments' do
       it('raises ArgumentError') { expect { cn.base64d(nil,nil) }.to raise_error(ArgumentError) }


### PR DESCRIPTION
- Fix #224 reported by @chahn 
  - Remove `plain.force_encoding('UTF-8') from `Sisimai::MIME.base64d`
- Register `rfc3464-32.eml` as a sample, provided by @chahn 
- Update test code files related to the file above
