### PR TITLE
Sisimai::Rhost::NTTDOCOMO

### DIFF
--- a/lib/sisimai/rhost.rb
+++ b/lib/sisimai/rhost.rb
@@ -17,6 +17,7 @@ module Sisimai
         '.email.ua'                   => 'IUA',
         'lsean.ezweb.ne.jp'           => 'KDDI',
         'msmx.au.com'                 => 'KDDI',
+        'mfsmax.docomo.ne.jp'         => 'NTTDOCOMO',
         'charter.net'                 => 'Spectrum',
         'cox.net'                     => 'Cox',
         '.qq.com'                     => 'TencentQQ',

--- a/lib/sisimai/rhost/nttdocomo.rb
+++ b/lib/sisimai/rhost/nttdocomo.rb
@@ -1,0 +1,118 @@
+module Sisimai
+  module Rhost
+    # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Data object as an argument
+    # of get() method when the value of "rhost" of the object is "mfsmax.docomo.ne.jp". This class
+    # is called only Sisimai::Data class.
+    module NTTDOCOMO
+      class << self
+        MessagesOf = {
+          'mailboxfull' => %r/552 too much mail data/,
+          'toomanyconn' => %r/552 too many recipients/,
+          'syntaxerror' => %r/(?:503 bad sequence of commands|504 command parameter not implemented)/,
+        }.freeze
+
+        # Detect bounce reason from NTT DOCOMO
+        # @param    [Sisimai::Data] argvs   Parsed email object
+        # @return   [String]                The bounce reason for docomo.ne.jp
+        def get(argvs)
+          statuscode = argvs['deliverystatus']          || ''
+          commandtxt = argvs['smtpcommand']             || ''
+          esmtperror = argvs['diagnosticcode'].downcase || ''
+          reasontext = ''
+
+          # Check the value of Status: field, an SMTP Reply Code, and the SMTP Command
+          if statuscode == '5.1.1' || statuscode == '5.0.911'
+            #    ----- Transcript of session follows -----
+            # ... while talking to mfsmax.docomo.ne.jp.:
+            # >>> RCPT To:<***@docomo.ne.jp>
+            # <<< 550 Unknown user ***@docomo.ne.jp
+            # 550 5.1.1 <***@docomo.ne.jp>... User unknown
+            # >>> DATA
+            # <<< 503 Bad sequence of commands
+            reasontext = 'userunknown'
+
+          elsif statuscode == '5.2.0'
+            #    ----- The following addresses had permanent fatal errors -----
+            # <***@docomo.ne.jp>
+            # (reason: 550 Unknown user ***@docomo.ne.jp)
+            # 
+            #    ----- Transcript of session follows -----
+            # ... while talking to mfsmax.docomo.ne.jp.:
+            # >>> DATA
+            # <<< 550 Unknown user ***@docomo.ne.jp
+            # 554 5.0.0 Service unavailable
+            # ...
+            # Final-Recipient: RFC822; ***@docomo.ne.jp
+            # Action: failed
+            # Status: 5.2.0
+            reasontext = 'filtered'
+
+          else
+            # The value of "Diagnostic-Code:" field is not empty
+            MessagesOf.each_key do |e|
+              # Try to match the error message with message patterns defined in "MessagesOf"
+              next unless esmtperror =~ MessagesOf[e]
+              reasontext = e
+              break
+            end
+          end
+
+          if reasontext.empty?
+            # A bounce reason did not decide from a status code, an error message.
+            if statuscode == '5.0.0'
+              # Status: 5.0.0
+              if commandtxt == 'RCPT'
+                # Your message to the following recipients cannot be delivered:
+                #
+                # <***@docomo.ne.jp>:
+                # mfsmax.docomo.ne.jp [203.138.181.112]:
+                # >>> RCPT TO:<***@docomo.ne.jp>
+                # <<< 550 Unknown user ***@docomo.ne.jp
+                # ...
+                #
+                # Final-Recipient: rfc822; ***@docomo.ne.jp
+                # Action: failed
+                # Status: 5.0.0
+                # Remote-MTA: dns; mfsmax.docomo.ne.jp [203.138.181.112]
+                # Diagnostic-Code: smtp; 550 Unknown user ***@docomo.ne.jp
+                reasontext = 'userunknown'
+
+              elsif commandtxt == 'DATA'
+                # <***@docomo.ne.jp>: host mfsmax.docomo.ne.jp[203.138.181.240] said:
+                # 550 Unknown user ***@docomo.ne.jp (in reply to end of DATA
+                # command)
+                # ...
+                # Final-Recipient: rfc822; ***@docomo.ne.jp
+                # Original-Recipient: rfc822;***@docomo.ne.jp
+                # Action: failed
+                # Status: 5.0.0
+                # Remote-MTA: dns; mfsmax.docomo.ne.jp
+                # Diagnostic-Code: smtp; 550 Unknown user ***@docomo.ne.jp
+                reasontext = 'rejected'
+
+              else
+                # Rejected by other SMTP commands: AUTH, MAIL,
+                #   もしもこのブロックを通過するNTTドコモからのエラーメッセージを見つけたら
+                #   https://github.com/sisimai/p5-sisimai/issues からご連絡ねがいます。
+                #
+                #   If you found a error message from mfsmax.docomo.ne.jp which passes this block,
+                #   please open an issue at https://github.com/sisimai/p5-sisimai/issues .
+              end
+            else
+              # Status: field is neither 5.0.0 nor values defined in code above
+              #   もしもこのブロックを通過するNTTドコモからのエラーメッセージを見つけたら
+              #   https://github.com/sisimai/p5-sisimai/issues からご連絡ねがいます。
+              #
+              #   If you found a error message from mfsmax.docomo.ne.jp which passes this block,
+              #
+            end
+          end
+
+          return reasontext
+        end
+
+      end
+    end
+  end
+end
+

--- a/set-of-emails/maildir/bsd/rhost-nttdocomo-01.eml
+++ b/set-of-emails/maildir/bsd/rhost-nttdocomo-01.eml
@@ -1,0 +1,62 @@
+Return-Path: <MAILER-DAEMON@nijo.example.jp>
+Received: from localhost (localhost)
+	by nijo.example.jp (V8/cf) id 2A18Nuql028789;
+	Tue, 1 Nov 2022 17:23:56 +0900
+Date: Tue, 1 Nov 2022 17:23:56 +0900
+From: Mail Delivery Subsystem <poostmaster@example.jp>
+Message-Id: <202211010823.2A18Nuql028789@nijo.example.jp>
+To: <le@example.jp>
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="2A18Nuql028789.1667291036/nijo.example.jp"
+Subject: Returned mail: see transcript for details
+Auto-Submitted: auto-generated (failure)
+
+This is a MIME-encapsulated message
+
+--2A18Nuql028789.1667291036/nijo.example.jp
+
+The original message was received at Tue, 1 Nov 2022 17:23:25 +0900
+from localhost [127.0.0.1]
+
+   ----- The following addresses had permanent fatal errors -----
+<azumakuniyuki@ntt.docomo.example.ne.jp>
+    (reason: 550 Unknown user azumakuniyuki@ntt.docomo.example.ne.jp)
+
+   ----- Transcript of session follows -----
+... while talking to mfsmax.docomo.ne.jp.:
+>>> DATA
+<<< 550 Unknown user azumakuniyuki@ntt.docomo.example.ne.jp
+554 5.0.0 Service unavailable
+
+--2A18Nuql028789.1667291036/nijo.example.jp
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; nijo.example.jp
+Received-From-MTA: DNS; localhost
+Arrival-Date: Tue, 1 Nov 2022 17:23:25 +0900
+
+Final-Recipient: RFC822; azumakuniyuki@ntt.docomo.example.ne.jp
+Action: failed
+Status: 5.2.0
+Remote-MTA: DNS; mfsmax.docomo.ne.jp
+Diagnostic-Code: SMTP; 550 Unknown user azumakuniyuki@ntt.docomo.example.ne.jp
+Last-Attempt-Date: Tue, 1 Nov 2022 17:23:56 +0900
+
+--2A18Nuql028789.1667291036/nijo.example.jp
+Content-Type: message/rfc822
+
+Return-Path: <le@example.jp>
+Received: from [127.0.0.1] (localhost [127.0.0.1])
+	by nijo.example.jp (V8/cf) with ESMTP id 2A18N1ql028769
+	for <azumakuniyuki@ntt.docomo.example.ne.jp>; Tue, 1 Nov 2022 17:23:25 +0900
+Date: Tue, 1 Nov 2022 17:23:01 +0900
+Message-Id: <202211010823.2A18N1ql028769@nijo.example.jp>
+Subject: TEST FROM NIJO(1)
+To: azumakuniyuki@ntt.docomo.example.ne.jp
+From: le@example.jp
+
+TEST(2)
+
+--2A18Nuql028789.1667291036/nijo.example.jp--
+

--- a/set-of-emails/maildir/bsd/rhost-nttdocomo-02.eml
+++ b/set-of-emails/maildir/bsd/rhost-nttdocomo-02.eml
@@ -1,0 +1,89 @@
+Return-Path: <>
+Received: from mbox.example.jp (6j.example.jp [192.0.2.12])
+	by nijo.example.jp (V8/cf) with ESMTP id 2A1G9IPF003550
+	for <kijitora@example.jp>; Wed, 2 Nov 2022 01:09:18 +0900
+Received: by mbox.example.jp (Postfix)
+	id 4N1w263TMDz1wYtp; Wed,  2 Nov 2022 01:09:18 +0900 (JST)
+Date: Wed,  2 Nov 2022 01:09:18 +0900 (JST)
+From: MAILER-DAEMON@mbox.example.jp (Mail Delivery System)
+Subject: Undelivered Mail Returned to Sender
+To: kijitora@example.jp
+Auto-Submitted: auto-replied
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="4N1w261vJbz1wYv9.1667318958/mbox.example.jp"
+Message-Id: <4N1w263TMDz1wYtp@mbox.example.jp>
+
+This is a MIME-encapsulated message.
+
+--4N1w261vJbz1wYv9.1667318958/mbox.example.jp
+Content-Description: Notification
+Content-Type: text/plain; charset=us-ascii
+
+This is the mail system at host mbox.example.jp.
+
+I'm sorry to have to inform you that your message could not
+be delivered to one or more recipients. It's attached below.
+
+For further assistance, please send mail to postmaster.
+
+If you do so, please include this problem report. You can
+delete your own text from the attached returned message.
+
+                   The mail system
+
+<azumakuniyuki@ntt.docomo.example.ne.jp>: host mfsmax.docomo.ne.jp[203.138.181.240] said:
+    550 Unknown user azumakuniyuki@ntt.docomo.example.ne.jp (in reply to end of DATA
+    command)
+
+--4N1w261vJbz1wYv9.1667318958/mbox.example.jp
+Content-Description: Delivery report
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; mbox.example.jp
+X-Postfix-Queue-ID: 4N1w261vJbz1wYv9
+X-Postfix-Sender: rfc822; kijitora@example.jp
+Arrival-Date: Wed,  2 Nov 2022 01:09:18 +0900 (JST)
+
+Final-Recipient: rfc822; azumakuniyuki@ntt.docomo.example.ne.jp
+Original-Recipient: rfc822;azumakuniyuki@ntt.docomo.example.ne.jp
+Action: failed
+Status: 5.0.0
+Remote-MTA: dns; mfsmax.docomo.ne.jp
+Diagnostic-Code: smtp; 550 Unknown user azumakuniyuki@ntt.docomo.example.ne.jp
+
+--4N1w261vJbz1wYv9.1667318958/mbox.example.jp
+Content-Description: Undelivered Message
+Content-Type: message/rfc822
+
+Return-Path: <kijitora@example.jp>
+Received: from mbox.example.jp (localhost [127.0.0.1])
+	by mbox.example.jp (Postfix) with ESMTP id 4N1w261vJbz1wYv9
+	for <azumakuniyuki@ntt.docomo.example.ne.jp>; Wed,  2 Nov 2022 01:09:18 +0900 (JST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.jp;
+	s=nekochan; t=1667318958;
+	bh=Rcw09b0VqpSsRy3duiZI5bXVf5Zz0hewV7vRzHCVJtw=;
+	h=From:Subject:Date:To:From;
+	b=ChN9gLs+vvYZLRCAxMyvjlM3RzW95tHMBEfD9jxScvqmCrQLLUettVRJSRNXqSipr
+	 upfnU+QoGWbqbrNEKFrxatZrDNyHSspWCd29nBbbLteV92RxVw2kX8Wb9rltRf6lRN
+	 jUy+ANmVMvFOqVKvDRJi/JcvpHz12mL5JqRLUI04zi0OSljIS87KFHCUd+FdHeysez
+	 +ezc42Yw6y44VF7ptXBEP0WQ/+p+uCnrMVyMGzCeVvv8X6lr/BBiVdIMJBfXcLRid4
+	 dACf0Kuob5cdCsJ37JeY5FT/3SzlO+Ia6xR4lXGnI5b5RMuURq7LHb9LU/mgQb19Lf
+	 8cuI2XYTOA7WQ==
+Received: from smtpclient.apple (p22.kyoto.example.ad.jp [192.0.2.254])
+	by mbox.example.jp (Postfix) with ESMTPSA id 4N1w256Ccdz1wYtp
+	for <azumakuniyuki@ntt.docomo.example.ne.jp>; Wed,  2 Nov 2022 01:09:17 +0900 (JST)
+From: "Neko, Nyaan" <kijitora@example.jp>
+Content-Type: text/plain;
+	charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+Mime-Version: 1.0 (Mac OS X Mail 16.0 \(3696.100.31\))
+Subject: Nyaan
+Message-Id: <E7C0BEB1-BA8B-4639-B37B-A8D4A8494900@example.jp>
+Date: Wed, 2 Nov 2022 01:09:17 +0900
+To: azumakuniyuki@ntt.docomo.example.ne.jp
+X-Mailer: Apple Mail (2.3696.100.31)
+X-Virus-Scanned: ClamAV using ClamSMTP
+
+
+--4N1w261vJbz1wYv9.1667318958/mbox.example.jp--

--- a/set-of-emails/maildir/bsd/rhost-nttdocomo-03.eml
+++ b/set-of-emails/maildir/bsd/rhost-nttdocomo-03.eml
@@ -1,0 +1,79 @@
+Return-Path: <>
+X-Original-To: sabatora@libsisimai.org
+Delivered-To: sabatora@libsisimai.org
+Received: from mbox.example.jp (localhost [127.0.0.1])
+	by mbox.example.jp (Postfix) with ESMTP id 4N1jYH5mF8z1wYv2
+	for <sabatora@libsisimai.org>; Tue,  1 Nov 2022 17:17:07 +0900 (JST)
+Received: from 4j.example.jp (4j.example.jp [192.0.2.45])
+	by mbox.example.jp (Postfix) with ESMTP id 4N1jYH4vf9z1wYtp
+	for <sabatora@libsisimai.org>; Tue,  1 Nov 2022 17:17:07 +0900 (JST)
+Authentication-Results: mbox.example.jp; dmarc=none (p=none dis=none) header.from=4j.example.jp
+Authentication-Results: mbox.example.jp; spf=pass smtp.helo=4j.example.jp
+Received: by 4j.example.jp (Postfix)
+	id 5619AC00844; Tue,  1 Nov 2022 17:17:21 +0900 (JST)
+Date: Tue,  1 Nov 2022 17:17:21 +0900 (JST)
+From: MAILER-DAEMON@4j.example.jp (Mail Delivery System)
+Subject: Undelivered Mail Returned to Sender
+To: sabatora@libsisimai.org
+Auto-Submitted: auto-replied
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="18E1AC6C55C.1667290641/4j.example.jp"
+Message-Id: <20221101081721.5619AC00844@4j.example.jp>
+X-Virus-Scanned: ClamAV using ClamSMTP
+
+This is a MIME-encapsulated message.
+
+--18E1AC6C55C.1667290641/4j.example.jp
+Content-Description: Notification
+Content-Type: text/plain; charset=us-ascii
+
+This is the mail system at host 4j.example.jp.
+
+I'm sorry to have to inform you that your message could not
+be delivered to one or more recipients. It's attached below.
+
+For further assistance, please send mail to postmaster.
+
+If you do so, please include this problem report. You can
+delete your own text from the attached returned message.
+
+                   The mail system
+
+<azumakuniyuki@ntt.docomo.example.ne.jp>: host mfsmax.docomo.ne.jp[203.138.180.240] said:
+    550 Unknown user azumakuniyuki@ntt.docomo.example.ne.jp (in reply to end of DATA
+    command)
+
+--18E1AC6C55C.1667290641/4j.example.jp
+Content-Description: Delivery report
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; 4j.example.jp
+X-Postfix-Queue-ID: 18E1AC6C55C
+X-Postfix-Sender: rfc822; sabatora@libsisimai.org
+Arrival-Date: Tue,  1 Nov 2022 17:16:42 +0900 (JST)
+
+Final-Recipient: rfc822; azumakuniyuki@ntt.docomo.example.ne.jp
+Original-Recipient: rfc822;azumakuniyuki@ntt.docomo.example.ne.jp
+Action: failed
+Status: 5.0.0
+Remote-MTA: dns; mfsmax.docomo.ne.jp
+Diagnostic-Code: smtp; 550 Unknown user azumakuniyuki@ntt.docomo.example.ne.jp
+
+--18E1AC6C55C.1667290641/4j.example.jp
+Content-Description: Undelivered Message
+Content-Type: message/rfc822
+
+Return-Path: <sabatora@libsisimai.org>
+Received: from [127.0.0.1] (localhost [127.0.0.1])
+	by 4j.example.jp (Postfix) with ESMTP id 18E1AC6C55C
+	for <azumakuniyuki@ntt.docomo.example.ne.jp>; Tue,  1 Nov 2022 17:16:42 +0900 (JST)
+Subject: Nyaan
+From: sabatora@libsisimai.org
+To: azumakuniyuki@ntt.docomo.example.ne.jp
+Message-Id: <20221101081656.18E1AC6C55C@4j.example.jp>
+Date: Tue,  1 Nov 2022 17:16:42 +0900 (JST)
+
+TEST(1)
+
+--18E1AC6C55C.1667290641/4j.example.jp--

--- a/test/private/lhost-courier.rb
+++ b/test/private/lhost-courier.rb
@@ -2,8 +2,8 @@ module LhostEngineTest::Private
   module Courier
     IsExpected = {
       # INDEX => [['D.S.N.', 'replycode', 'REASON', 'hardbounce'], [...]]
-      '01001' => [['5.0.0',   '550', 'filtered',        false]],
-      '01002' => [['5.0.0',   '550', 'filtered',        false]],
+      '01001' => [['5.0.0',   '550', 'rejected',        false]],
+      '01002' => [['5.0.0',   '550', 'rejected',        false]],
       '01003' => [['5.7.1',   '550', 'blocked',         false]],
       '01004' => [['5.0.0',   '550', 'userunknown',     true]],
       '01005' => [['5.1.1',   '550', 'userunknown',     true]],

--- a/test/private/lhost-postfix.rb
+++ b/test/private/lhost-postfix.rb
@@ -2,7 +2,7 @@ module LhostEngineTest::Private
   module Postfix
     IsExpected = {
       # INDEX => [['D.S.N.', 'replycode', 'REASON', 'hardbounce'], [...]]
-      '01001' => [['5.0.0',   '550', 'filtered',        false]],
+      '01001' => [['5.0.0',   '550', 'rejected',        false]],
       '01002' => [['5.1.1',   '550', 'userunknown',     true]],
       '01003' => [['5.0.0',   '550', 'userunknown',     true]],
       '01004' => [['5.1.1',   '550', 'userunknown',     true]],
@@ -35,10 +35,10 @@ module LhostEngineTest::Private
       '01031' => [['5.0.0',   '550', 'userunknown',     true]],
       '01032' => [['5.0.0',   '550', 'userunknown',     true]],
       '01033' => [['5.0.0',   '550', 'userunknown',     true]],
-      '01034' => [['5.0.0',   '550', 'filtered',        false]],
+      '01034' => [['5.0.0',   '550', 'rejected',        false]],
       '01035' => [['4.2.2',   '',    'mailboxfull',     false]],
       '01036' => [['5.4.4',   '',    'hostunknown',     true]],
-      '01037' => [['5.0.0',   '550', 'filtered',        false]],
+      '01037' => [['5.0.0',   '550', 'rejected',        false]],
       '01038' => [['5.0.0',   '550', 'blocked',         false]],
       '01039' => [['5.1.1',   '',    'userunknown',     true]],
       '01040' => [['5.7.1',   '550', 'userunknown',     true]],
@@ -151,7 +151,7 @@ module LhostEngineTest::Private
       '01142' => [['5.0.0',   '550', 'blocked',         false]],
       '01143' => [['5.3.0',   '553', 'userunknown',     true]],
       '01144' => [['5.0.0',   '554', 'suspend',         false]],
-      '01145' => [['5.0.0',   '550', 'filtered',        false]],
+      '01145' => [['5.0.0',   '550', 'rejected',        false]],
       '01146' => [['5.1.3',   '',    'userunknown',     true]],
       '01147' => [['5.1.1',   '550', 'userunknown',     true]],
       '01148' => [['5.2.1',   '550', 'userunknown',     true]],
@@ -280,6 +280,8 @@ module LhostEngineTest::Private
       '01269' => [['5.0.0',   '550', 'virusdetected',   false]],
       '01270' => [['5.0.0',   '554', 'norelaying',      false]],
       '01271' => [['5.0.0',   '554', 'contenterror',    false]],
+      '01272' => [['5.0.0',   '550', 'rejected',        false]],
+      '01273' => [['5.0.0',   '550', 'rejected',        false]],
     }
   end
 end

--- a/test/private/lhost-sendmail.rb
+++ b/test/private/lhost-sendmail.rb
@@ -233,6 +233,7 @@ module LhostEngineTest::Private
       '01227' => [['5.7.1',   '550', 'rejected',        false]],
       '01228' => [['5.1.1',   '550', 'userunknown',     true]],
       '01229' => [['5.4.1',   '550', 'rejected',        false]],
+      '01230' => [['5.2.0',   '550', 'filtered',        false]],
     }
   end
 end

--- a/test/public/mail-maildir-test.rb
+++ b/test/public/mail-maildir-test.rb
@@ -5,7 +5,7 @@ class MailMaildirTest < Minitest::Test
   Methods = { class: %w[new], object: %w[path dir file size handle offset read] }
   Samples = ['./set-of-emails/maildir/bsd', './set-of-emails/maildir/mac']
   Maildir = Sisimai::Mail::Maildir.new(Samples[0])
-  DirSize = 515
+  DirSize = 518
 
   def test_methods
     Methods[:class].each  { |e| assert_respond_to Sisimai::Mail::Maildir, e }

--- a/test/public/rhost-engine-test.rb
+++ b/test/public/rhost-engine-test.rb
@@ -15,7 +15,7 @@ module RhostEngineTest
       emailindex = ARGV[1] || 0
 
       # % grep -h module lib/sisimai/rhost/*.rb | grep -vE '(Sisimai|Rhost)' | awk '{ print $2 }'
-      rhostindex = %w[Cox ExchangeOnline FrancePTT GoDaddy GoogleApps IUA KDDI Spectrum TencentQQ]
+      rhostindex = %w[Cox ExchangeOnline FrancePTT GoDaddy GoogleApps IUA KDDI NTTDOCOMO Spectrum TencentQQ]
       enginelist = []
       enginename = ''
 

--- a/test/public/rhost-nttdocomo.rb
+++ b/test/public/rhost-nttdocomo.rb
@@ -1,0 +1,11 @@
+module RhostEngineTest::Public
+  module NTTDOCOMO
+    IsExpected = {
+      # INDEX => [['D.S.N.', 'replycode', 'REASON', 'hardbounce'], [...]]
+      '01' => [['5.2.0',   '550', 'filtered',        false]],
+      '02' => [['5.0.0',   '550', 'rejected',        false]],
+      '03' => [['5.0.0',   '550', 'rejected',        false]],
+    }
+  end
+end
+


### PR DESCRIPTION
- Forparsing more strictly a bounce mail returned from `mfsmax.docomo.ne.jp`
- `lib/sisimai/rhost/nttdocomo.rb`
- `test/public/rhost-nttdocomo.rb`
- `set-of-emails/maildir/bsd/rhost-nttdocomo-0[1-3].eml`
