### PR TITLE
Prevent Regex Denial of Service in Sisimai::String.to_plain

### DIFF
--- a/lib/sisimai/string.rb
+++ b/lib/sisimai/string.rb
@@ -66,8 +66,8 @@ module Sisimai
           # 3. <a href = 'http://...'>...</a> to " http://... "
           # 4. <a href = 'mailto:...'>...</a> to " Value <mailto:...> "
           plain.scrub!('?')
-          plain.gsub!(%r|<head>.+</head>|im, '')
-          plain.gsub!(%r|<style.+?>.+</style>|im, '')
+          plain.gsub!(%r|<head>.*?</head>|im, '')
+          plain.gsub!(%r|<style.*?>.*?</style>|im, '')
           plain.gsub!(%r|<a\s+href\s*=\s*['"](https?://.+?)['"].*?>(.*?)</a>|i, '[\2](\1)')
           plain.gsub!(%r|<a\s+href\s*=\s*["']mailto:([^\s]+?)["']>(.*?)</a>|i, '[\2](mailto:\1)')
 


### PR DESCRIPTION
We've hit a ReDoS in production given a email HTML body that looks somewhat like the this: https://gist.githubusercontent.com/gmcabrita/e5dc0332473fc2e3a7a407434c8d21c7/raw/00b12035e5e1b685469f143b94301a50306376ba/example.html

This is the same fix we monkeypatched in our production application.