### PR TITLE
Handle Rhost.get returning nil

### DIFF
--- a/lib/sisimai/data.rb
+++ b/lib/sisimai/data.rb
@@ -303,7 +303,7 @@ module Sisimai
           if r.empty?
             # Failed to detect a bounce reason by the value of "rhost"
             r = Sisimai::Rhost.get(o, o.destination) if Sisimai::Rhost.match(o.destination)
-            r = Sisimai::Reason.get(o) if r.empty?
+            r = Sisimai::Reason.get(o) if r.nil? || r.empty?
             r = 'undefined' if r.empty?
           end
           o.reason = r


### PR DESCRIPTION
We are getting `NoMethodError: undefined method 'empty?' for nil:NilClass` in production on https://github.com/sisimai/rb-sisimai/blob/master/lib/sisimai/data.rb#L306

I seems like the cause is `Rhost.get` can return `nil` in some situations, like: https://github.com/sisimai/rb-sisimai/blob/master/lib/sisimai/rhost.rb#L64

