### PR TITLE
Tiny code improvement on Sisimai::Lhost::EinsUndEins

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,14 @@ RELEASE NOTES for Ruby version of Sisimai
 - releases: "https://github.com/sisimai/rb-sisimai/releases"
 - download: "https://rubygems.org/gems/sisimai"
 
+v4.25.16p1
+--------------------------------------------------------------------------------
+- release: ""
+- version: ""
+- changes:
+  - #256 Tiny code improvement on `Sisimai::Lhost::EinsUndEins` to parse bounce
+    emails in slightly different formats.
+
 v4.25.16
 --------------------------------------------------------------------------------
 - release: "Tue, 16 May 2023 15:11:22 +0900 (JST)"

--- a/lib/sisimai/lhost/einsundeins.rb
+++ b/lib/sisimai/lhost/einsundeins.rb
@@ -52,8 +52,9 @@ module Sisimai::Lhost
           # http://postmaster.1and1.com/en/error-messages?ip=%1s
           v = dscontents[-1]
 
-          if cv = e.match(/\A([^ ]+[@][^ ]+?)[:]?\z/)
-            # general@example.eu
+          if cv = e.match(/\A\s*([^ ]+[@][^ ]+?)[:]?\z/)
+            # general@example.eu OR
+            # the line begin with 4 space characters, end with ":" like "    neko@example.eu:"
             if v['recipient']
               # There are multiple recipient addresses in the message body.
               dscontents << Sisimai::Lhost.DELIVERYSTATUS

--- a/spec/sisimai/lhost/private-einsundeins_spec.rb
+++ b/spec/sisimai/lhost/private-einsundeins_spec.rb
@@ -4,7 +4,17 @@ enginename = 'EinsUndEins'
 isexpected = [
   { 'n' => '01001', 'r' => /mailboxfull/ },
   { 'n' => '01002', 'r' => /mailboxfull/ },
-  { 'n' => '01003', 'r' => /mesgtoobig/ },
+  { 'n' => '01003', 'r' => /mesgtoobig/  },
+  { 'n' => '01004', 'r' => /userunknown/ },
+  { 'n' => '01005', 'r' => /userunknown/ },
+  { 'n' => '01006', 'r' => /userunknown/ },
+  { 'n' => '01007', 'r' => /userunknown/ },
+  { 'n' => '01008', 'r' => /userunknown/ },
+  { 'n' => '01009', 'r' => /userunknown/ },
+  { 'n' => '01010', 'r' => /userunknown/ },
+  { 'n' => '01011', 'r' => /userunknown/ },
+  { 'n' => '01012', 'r' => /userunknown/ },
+  { 'n' => '01013', 'r' => /userunknown/ },
 ]
 Sisimai::Lhost::Code.maketest(enginename, isexpected, true)
 


### PR DESCRIPTION
- Import Pull-Request sisimai/p5-sisimai#497
- Tiny code improvement on Sisimai::Lhost::EinsUndEins
- Add 10 emails into `set-of-emails/private/lhost-einsundeins` as a private sample
