### PR TITLE
Implement some classes in Sisimai::Rhost::* 

### DIFF
--- a/lib/sisimai/fact.rb
+++ b/lib/sisimai/fact.rb
@@ -383,6 +383,7 @@ module Sisimai
         # REASON: Decide the reason of email bounce
         if o['reason'].empty? || RetryIndex[o['reason']]
           # The value of "reason" is empty or is needed to check with other values again
+          o['reason'] = '' if o['reason'].start_with?('onhold', 'undefined')
           re = ''; de = o['destination']
           re = Sisimai::Rhost.get(o) if Sisimai::Rhost.match(o['rhost'])
           if re.empty?

--- a/lib/sisimai/rhost.rb
+++ b/lib/sisimai/rhost.rb
@@ -5,17 +5,17 @@ module Sisimai
   module Rhost
     class << self
       RhostClass = {
-          'Cox'       => ['cox.net'],
-          'FrancePTT' => ['.laposte.net', '.orange.fr', '.wanadoo.fr'],
-          'GoDaddy'   => ['smtp.secureserver.net', 'mailstore1.secureserver.net'],
-          'Google'    => ['aspmx.l.google.com', 'gmail-smtp-in.l.google.com'],
-          'IUA'       => ['.email.ua'],
-          'KDDI'      => ['.ezweb.ne.jp', 'msmx.au.com'],
-          'Microsoft' => ['.prod.outlook.com', '.protection.outlook.com'],
-          'Mimecast'  => ['.mimecast.com'],
-          'NTTDOCOMO' => ['mfsmax.docomo.ne.jp'],
-          'Spectrum'  => ['charter.net'],
-          'Tencent'   => ['.qq.com'],
+        'Cox'       => ['cox.net'],
+        'FrancePTT' => ['.laposte.net', '.orange.fr', '.wanadoo.fr'],
+        'GoDaddy'   => ['smtp.secureserver.net', 'mailstore1.secureserver.net'],
+        'Google'    => ['aspmx.l.google.com', 'gmail-smtp-in.l.google.com'],
+        'IUA'       => ['.email.ua'],
+        'KDDI'      => ['.ezweb.ne.jp', 'msmx.au.com'],
+        'Microsoft' => ['.prod.outlook.com', '.protection.outlook.com'],
+        'Mimecast'  => ['.mimecast.com'],
+        'NTTDOCOMO' => ['mfsmax.docomo.ne.jp'],
+        'Spectrum'  => ['charter.net'],
+        'Tencent'   => ['.qq.com'],
       }.freeze
 
       # The value of "rhost" is listed in RhostClass or not

--- a/lib/sisimai/rhost.rb
+++ b/lib/sisimai/rhost.rb
@@ -5,6 +5,7 @@ module Sisimai
   module Rhost
     class << self
       RhostClass = {
+        'Apple'     => ['.mail.icloud.com', '.apple.com', '.me.com'],
         'Cox'       => ['cox.net'],
         'FrancePTT' => ['.laposte.net', '.orange.fr', '.wanadoo.fr'],
         'GoDaddy'   => ['smtp.secureserver.net', 'mailstore1.secureserver.net'],
@@ -16,6 +17,7 @@ module Sisimai
         'NTTDOCOMO' => ['mfsmax.docomo.ne.jp'],
         'Spectrum'  => ['charter.net'],
         'Tencent'   => ['.qq.com'],
+        'YahooInc'  => ['.yahoodns.net'],
       }.freeze
 
       # The value of "rhost" is listed in RhostClass or not

--- a/lib/sisimai/rhost/apple.rb
+++ b/lib/sisimai/rhost/apple.rb
@@ -1,0 +1,93 @@
+module Sisimai
+  module Rhost
+    # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
+    # of get() method when the value of "destination" of the object is "mail.icloud.com" or "apple.com".
+    # This class is called only Sisimai::Fact class.
+    module Apple
+      class << self
+        MessagesOf = {
+          'authfailure' => [
+            # - 554 5.7.1 Your message was rejected due to example.jp's DMARC policy.
+            #   See https://support.apple.com/en-us/HT204137 for
+            # - 554 5.7.1 [HME1] This message was blocked for failing both SPF and DKIM authentication
+            #   checks. See https://support.apple.com/en-us/HT204137 for mailing best practices
+            's dmarc policy',
+            'blocked for failing both spf and dkim autentication checks',
+          ],
+          'blocked' => [
+            # - 550 5.7.0 Blocked - see https://support.proofpoint.com/dnsbl-lookup.cgi?ip=192.0.1.2
+            # - 550 5.7.1 Your email was rejected due to having a domain present in the Spamhaus
+            #   DBL -- see https://www.spamhaus.org/dbl/
+            # - 550 5.7.1 Mail from IP 192.0.2.1 was rejected due to listing in Spamhaus SBL.
+            #   For details please see http://www.spamhaus.org/query/bl?ip=x.x.x.x
+            # - 554 ****-smtpin001.me.com ESMTP not accepting connections
+            'rejected due to having a domain present in the spamhaus',
+            'rejected due to listing in spamhaus',
+            'blocked - see https://support.proofpoint.com/dnsbl-lookup',
+            'not accepting connections',
+          ],
+          'hasmoved' => [
+            # - 550 5.1.6 recipient no longer on server: *****@icloud.com
+            'recipient no longer on server',
+          ],
+          'mailboxfull' => [
+            # - 552 5.2.2 <****@icloud.com>: user is over quota (in reply to RCPT TO command)
+            'user is over quota',
+          ],
+          'norelaying' => [
+            # - 554 5.7.1 <*****@icloud.com>: Relay access denied
+            'relay access denied',
+          ],
+          'notaccept' => ['host/domain does not accept mail'],
+          'policyviolation' => [
+            # - 550 5.7.1 [CS01] Message rejected due to local policy.
+            #   Please visit https://support.apple.com/en-us/HT204137
+            'due to local policy',
+          ],
+          'rejected' => [
+            # - 450 4.1.8 <kijitora@example.jp>: Sender address rejected: Domain not found
+            'sender address rejected',
+          ],
+          'speeding' => [
+            # - 421 4.7.1 Messages to ****@icloud.com deferred due to excessive volume.
+            #   Try again later - https://support.apple.com/en-us/HT204137
+            'due to excessive volume',
+          ],
+          'userunknown' => [
+              # - 550 5.1.1 <****@icloud.com>: inactive email address (in reply to RCPT TO command)
+              # - 550 5.1.1 unknown or illegal alias: ****@icloud.com
+              'inactive email address',
+              'user does not exist',
+              'unknown or illegal alias',
+          ],
+        }.freeze
+
+        # Detect bounce reason from Apple iCloud Mail
+        # @param    [Sisimai::Fact] argvs   Parsed email object
+        # @return   [String]                The bounce reason for Apple
+        # @see      https://support.apple.com/en-us/102322
+        #           https://www.postmastery.com/icloud-postmastery-page/
+        #           https://smtpfieldmanual.com/provider/apple
+        def get(argvs)
+          return argvs['reason'] unless argvs['reason'].empty?
+
+          issuedcode = argvs['diagnosticcode'].downcase
+          reasontext = ''
+
+          MessagesOf.each_key do |e|
+            MessagesOf[e].each do |f|
+              next unless issuedcode.include?(f)
+              reasontext = e
+              break
+            end
+            break if reasontext.size > 0
+          end
+
+          return reasontext
+        end
+
+      end
+    end
+  end
+end
+

--- a/lib/sisimai/rhost/yahooinc.rb
+++ b/lib/sisimai/rhost/yahooinc.rb
@@ -1,0 +1,102 @@
+module Sisimai
+  module Rhost
+    # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
+    # of get() method when the value of "destination" of the object is "*.yahoodns.net".
+    # This class is called only Sisimai::Fact class.
+    module YahooInc
+      class << self
+        MessagesOf = {
+          'authfailure' => [
+            # - 550 5.7.9 This mail has been blocked because the sender is unauthenticated. Yahoo
+            #   requires all senders to authenticate with either SPF or DKIM.
+            'yahoo requires all senders to authenticate with either spf or dkim',
+          ],
+          'badreputation' => [
+            # - 421 4.7.0 [TSS04] Messages from 192.0.2.25 temporarily deferred due to unexpected
+            #   volume or user complaints - 4.16.55.1;
+            #   see https://postmaster.yahooinc.com/error-codes (in reply to MAIL FROM command))
+            'temporarily deferred due to unexpected volume or user complaints',
+          ],
+          'blocked' => [
+            # - 553 5.7.1 [BL21] Connections will not be accepted from 192.0.2.25,
+            #   because the ip is in Spamhaus's list; see http://postmaster.yahoo.com/550-bl23.html
+            # - 553 5.7.1 [BL23] Connections not accepted from IP addresses on Spamhaus XBL;
+            #   see http://postmaster.yahoo.com/errors/550-bl23.html [550]",
+            " because the ip is in spamhaus's list;",
+            'not accepted from ip addresses on spamhaus xbl',
+          ],
+          'norelaying' => [
+            # - 550 relaying denied for <***@yahoo.com>
+            'relaying denied for ',
+          ],
+          'notcomplaintrfc' => ['headers are not rfc compliant'],
+          'policyviolation' => [
+            # - 554 Message not allowed - [PH01] Email not accepted for policy reasons.
+            #   Please visit https://postmaster.yahooinc.com/error-codes
+            # - 554 5.7.9 Message not accepted for policy reasons. 
+            #   See https://postmaster.yahooinc.com/error-codes
+            'not accepted for policy reasons',
+          ],
+          'rejected' => [
+            # - 553 5.7.2 [TSS09] All messages from 192.0.2.25 will be permanently deferred;
+            #   Retrying will NOT succeed. See https://postmaster.yahooinc.com/error-codes
+            # - 553 5.7.2 [TSS11] All messages from 192.0.2.25 will be permanently deferred;
+            #   Retrying will NOT succeed. See https://postmaster.yahooinc.com/error-codes
+            ' will be permanently deferred',
+          ],
+          'speeding' => [
+            # - 450 User is receiving mail too quickly
+            'User is receiving mail too quickly',
+          ],
+          'suspend' => [
+            # - 554 delivery error: dd ****@yahoo.com is no longer valid.
+            # - 554 30 Sorry, your message to *****@aol.jp cannot be delivered.
+            #   This mailbox is disabled (554.30)
+            ' is no longer valid.',
+            'This mailbox is disabled',
+          ],
+          'syntaxerror' => [
+            # - 501 Syntax error in parameters or arguments
+            'syntax error in parameters or arguments',
+          ],
+          'toomanyconn' => [
+            # - 421 Max message per connection reached, closing transmission channel
+            'max message per connection reached',
+          ],
+          'userunknown' => [
+            # - 554 delivery error: dd This user doesn't have a yahoo.com account (***@yahoo.com)
+            # - 552 1 Requested mail action aborted, mailbox not found (in reply to end of DATA command)
+            "dd this user doesn't have a ",
+            'mailbox not found',
+          ],
+        }.freeze
+
+        # Detect bounce reason from Yahoo Inc. (*.yahoodns.net)
+        # @param    [Sisimai::Fact] argvs   Parsed email object
+        # @return   [String]                The bounce reason for YahooInc
+        # @see      https://senders.yahooinc.com/smtp-error-codes
+        #           https://smtpfieldmanual.com/provider/yahoo
+        #           https://www.postmastery.com/yahoo-postmaster/
+        def get(argvs)
+          return argvs['reason'] unless argvs['reason'].empty?
+
+          issuedcode = argvs['diagnosticcode'].downcase
+          reasontext = ''
+
+          MessagesOf.each_key do |e|
+            MessagesOf[e].each do |f|
+              next unless issuedcode.include?(f)
+              reasontext = e
+              break
+            end
+            break if reasontext.size > 0
+          end
+
+          return reasontext
+        end
+
+      end
+    end
+  end
+end
+

--- a/set-of-emails/maildir/bsd/rhost-apple-01.eml
+++ b/set-of-emails/maildir/bsd/rhost-apple-01.eml
@@ -1,0 +1,79 @@
+Return-path: <>
+Envelope-to: nekonyaan@example.com
+Delivery-date: Thu, 17 Jul 2014 23:34:45 -0500
+Received: from mail-in2.apple.com ([192.0.2.1]:1111)
+	by neko.example.com with esmtp (Exim 4.80)
+	id 20000A-00000B-NN
+	for nekonyaan@example.com; Thu, 17 Jul 2014 23:34:45 -0500
+From: <Mailer-Daemon@mail-in2.apple.com> (Mail Delivery System)
+Message-ID: <AA.BB.00000.00000CCC@mail-in2.apple.com>
+To: nekonyaan@example.com
+Subject: Undelivered Mail Returned to Sender
+Date: Thu, 17 Jul 2014 23:34:45 -0700
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+ boundary="RnJpIEp1bCAxMyAyMjowNzoyMyBKU1QgMjAxOAo="
+
+This is a MIME-encapsulated message.
+
+--RnJpIEp1bCAxMyAyMjowNzoyMyBKU1QgMjAxOAo=
+Content-Description: Notification
+Content-Type: text/plain
+
+I'm sorry to have to inform you that your message could not
+be delivered to one or more recipients. It's attached below.
+
+For further assistance, please send mail to <postmaster@example.jp>
+
+If you do so, please include this problem report. You can
+delete your own text from the attached returned message.
+
+<kijitora@example.jp>: 550 5.1.6 recipient no longer on server: kijitora@example.jp
+
+
+--RnJpIEp1bCAxMyAyMjowNzoyMyBKU1QgMjAxOAo=
+Content-Description: Delivery report
+Content-Type: message/delivery-status
+
+X-Symantec-Messaging-Gateway-Queue-ID: AA/AA-00000-00000000
+X-Symantec-Messaging-Gateway-Sender: rfc822; nekonyaan@example.com
+Reporting-MTA: dns; mail-in2.apple.com
+Arrival-Date: Thu, 17 Jul 2014 23:34:45 -0700
+
+Final-Recipient: rfc822; kijitora@example.jp
+Status: 5.1.6
+Action: failed
+Last-Attempt-Date: Thu, 17 Jul 2014 23:34:45 -0700
+Diagnostic-Code: smtp; 550 5.1.6 recipient no longer on server: kijitora@example.jp
+
+--RnJpIEp1bCAxMyAyMjowNzoyMyBKU1QgMjAxOAo=
+Content-Description: Undelivered Message
+Content-Type: message/rfc822
+
+Received: from r1.example.com (r1.example.com [203.0.113.4])
+	by mail-in2.apple.com (Apple Secure Mail Relay) with SMTP id AA.AA.00000.00000000; Thu, 17 Jul 2014 23:34:45 -0700 (PDT)
+Received: by r1.example.com (Postfix, from userid 2202)
+	id AAAAAAAACCCCC; Thu, 17 Jul 2014 23:34:45 -0500 (CDT)
+Received: from smtp2.example.com (smtp.example.com [192.0.2.225])
+	by r1.example.com (Postfix) with ESMTP id BBBBBBBB22222
+	for <kijitora@example.jp>; Thu, 17 Jul 2014 23:34:45 -0500 (CDT)
+Received: by smtp2.example.com (Postfix, from userid 2220)
+	id AAAAAAAA00000; Thu, 17 Jul 2014 23:34:45 -0500 (CDT)
+Received: from neko.example.com (neko.example.com [198.51.100.198])
+	by smtp2.example.com (Postfix) with ESMTP id EEEEEEEE11112
+	for <kijitora@example.jp>; Thu, 17 Jul 2014 23:34:45 -0500 (CDT)
+Received: from neko22 by neko.example.com with local (Exim 4.80)
+	(envelope-from <nekonyaan@example.com>)
+	id 2Aneko-00022X-BB
+	for kijitora@example.jp; Thu, 17 Jul 2014 23:34:45 -0500
+To: kijitora@example.jp
+Subject: Nyaan
+Date: Thu, 17 Jul 2014 23:34:45 -0500
+From: "Neko, Nyaan" <nekonyaan@example.com>
+Message-ID: <c15e793e1c6acf9fbc39d1547bbd98b4@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain
+
+Nyaan
+
+--RnJpIEp1bCAxMyAyMjowNzoyMyBKU1QgMjAxOAo=--

--- a/set-of-emails/maildir/bsd/rhost-apple-02.eml
+++ b/set-of-emails/maildir/bsd/rhost-apple-02.eml
@@ -1,0 +1,81 @@
+Return-Path: <>
+Received: from mbox.example.jp (mail.example.jp [192.0.2.25])
+	by mx.example.jp (V8/cf) with ESMTP id 0AD0lpdN032754
+	for <postmaster@example.jp>; Fri, 13 Nov 2020 09:47:51 +0900
+Received: from mbox.example.jp (localhost [127.0.0.1])
+	by mbox.example.jp (Postfix) with ESMTP id 4CXKZH4NX1z22xZY
+	for <postmaster@sisimai.example.com>; Fri, 13 Nov 2020 09:47:51 +0900 (JST)
+Received: from smtp.example.jp (smtp.example.jp [203.0.113.127])
+	by mbox.example.jp (Postfix) with ESMTP id 4CXKZH3xdDz1yM4D
+	for <postmaster@sisimai.example.com>; Fri, 13 Nov 2020 09:47:51 +0900 (JST)
+Received: by smtp.example.jp (Postfix)
+	id 7344BD244EC; Fri, 13 Nov 2020 09:47:51 +0900 (JST)
+Date: Fri, 13 Nov 2020 09:47:51 +0900 (JST)
+From: MAILER-DAEMON@smtp.example.jp (Mail Delivery System)
+Subject: Undelivered Mail Returned to Sender
+To: postmaster@sisimai.example.com
+Auto-Submitted: auto-replied
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="3574FC0196A.1605228471/smtp.example.jp"
+Message-Id: <20201113004751.7344BD244EC@smtp.example.jp>
+X-Virus-Scanned: ClamAV using ClamSMTP
+
+This is a MIME-encapsulated message.
+
+--3574FC0196A.1605228471/smtp.example.jp
+Content-Description: Notification
+Content-Type: text/plain; charset=us-ascii
+
+This is the mail system at host smtp.example.jp.
+
+I'm sorry to have to inform you that your message could not
+be delivered to one or more recipients. It's attached below.
+
+For further assistance, please send mail to postmaster.
+
+If you do so, please include this problem report. You can
+delete your own text from the attached returned message.
+
+                   The mail system
+
+<kijitora@apple.example.com>: host mx01.mail.icloud.com[17.57.152.9] said: 554
+    5.7.1 Your message was rejected due to libsisimai.org's DMARC policy. See
+    https://support.apple.com/en-us/HT204137 for info (in reply to end of DATA
+    command)
+
+--3574FC0196A.1605228471/smtp.example.jp
+Content-Description: Delivery report
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; smtp.example.jp
+X-Postfix-Queue-ID: 3574FC0196A
+X-Postfix-Sender: rfc822; postmaster@sisimai.example.com
+Arrival-Date: Fri, 13 Nov 2020 09:47:12 +0900 (JST)
+
+Final-Recipient: rfc822; kijitora@apple.example.com
+Original-Recipient: rfc822;kijitora@apple.example.com
+Action: failed
+Status: 5.7.1
+Remote-MTA: dns; mx01.mail.icloud.com
+Diagnostic-Code: smtp; 554 5.7.1 Your message was rejected due to
+    libsisimai.org's DMARC policy. See https://support.apple.com/en-us/HT204137
+    for info
+
+--3574FC0196A.1605228471/smtp.example.jp
+Content-Description: Undelivered Message
+Content-Type: message/rfc822
+
+Return-Path: <postmaster@sisimai.example.com>
+Received: from [127.0.0.1] (localhost [127.0.0.1])
+	by smtp.example.jp (Postfix) with ESMTP id 3574FC0196A
+	for <kijitora@apple.example.com>; Fri, 13 Nov 2020 09:47:12 +0900 (JST)
+Subject: TEST FOR DMARC #6
+From: postmaster@libsisimai.org
+To: kijitora@apple.example.com
+Message-Id: <20201113004724.3574FC0196A@smtp.example.jp>
+Date: Fri, 13 Nov 2020 09:47:12 +0900 (JST)
+
+Nyaan
+
+--3574FC0196A.1605228471/smtp.example.jp--

--- a/set-of-emails/maildir/bsd/rhost-apple-03.eml
+++ b/set-of-emails/maildir/bsd/rhost-apple-03.eml
@@ -1,0 +1,75 @@
+Return-Path: <>
+Delivered-To: neko@example.jp
+Received: from smtp1.example.jp (smtp1 [192.0.2.26])
+	by mx1.example.jp (Postfix) with ESMTPS id SGXNhJQdfczZsR5q
+	for <kijitora@example.jp>; Thu, 29 Apr 2022 23:34:45 +0900 (JST)
+Received: by smtp1.example.jp (Postfix)
+	id jGd1g4yXDZz3NtXL; Thu, 29 Apr 2022 23:34:45 +0900 (JST)
+Date: Thu, 29 Apr 2022 23:34:45 +0900 (JST)
+From: MAILER-DAEMON@smtp1.example.jp (Mail Delivery System)
+To: kijitora@example.jp
+Message-Id: <jGd1g4yXDZz3NtXL@smtp1.example.jp>
+Subject: Undelivered Mail Returned to Sender
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="8nhz33cQRrzZfKG7.1697834505/smtp1.example.jp"
+MIME-Version: 1.0
+
+This is a MIME-encapsulated message.
+
+--8nhz33cQRrzZfKG7.1697834505/smtp1.example.jp
+Content-Description: Notification
+Content-Type: text/plain; charset=us-ascii
+
+This is the mail system at host smtp1.example.jp.
+
+I'm sorry to have to inform you that your message could not
+be delivered to one or more recipients. It's attached below.
+
+For further assistance, please send mail to postmaster.
+
+If you do so, please include this problem report. You can
+delete your own text from the attached returned message.
+
+                   The mail system
+
+<pseudo-local-part-of-apple-icloud-mail@icloud.com>: host mx02.mail.icloud.com[17.56.9.31] said: 552
+    5.2.2 <pseudo-local-part-of-apple-icloud-mail@icloud.com>: user is over quota (in reply to RCPT TO
+    command)
+
+--8nhz33cQRrzZfKG7.1697834505/smtp1.example.jp
+Content-Description: Delivery report
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; smtp1.example.jp
+X-Postfix-Queue-ID: 8nhz33cQRrzZfKG7
+X-Postfix-Sender: rfc822; kijitora@example.jp
+Arrival-Date: Thu, 29 Apr 2022 23:34:45 +0900 (JST)
+
+Final-Recipient: rfc822; pseudo-local-part-of-apple-icloud-mail@icloud.com
+Original-Recipient: rfc822;pseudo-local-part-of-apple-icloud-mail@icloud.com
+Action: failed
+Status: 5.2.2
+Remote-MTA: dns; mx02.mail.icloud.com
+Diagnostic-Code: smtp; 552 5.2.2 <pseudo-local-part-of-apple-icloud-mail@icloud.com>: user is over
+    quota
+
+--8nhz33cQRrzZfKG7.1697834505/smtp1.example.jp
+Content-Description: Undelivered Message
+Content-Type: message/rfc822
+
+Return-Path: <kijitora@example.jp>
+Received: from MAILHUB-1 (unknown [192.0.2.25])
+	by smtp1.example.jp (Postfix) with ESMTP id 8nhz33cQRrzZfKG7
+	for <pseudo-local-part-of-apple-icloud-mail@icloud.com>; Thu, 29 Apr 2022 23:34:45 +0900 (JST)
+MIME-Version: 1.0
+From: <kijitora@example.jp>
+To: <pseudo-local-part-of-apple-icloud-mail@icloud.com>
+Date: 29 Apr 2022 23:34:45 +0900
+Message-Id: <8nhz33cQRrzZfKG7@smtp1.example.jp>
+Content-Type: text/plain; charset=us-ascii
+Subject: Nyaan?
+
+Nyaan?
+
+--8nhz33cQRrzZfKG7.1697834505/smtp1.example.jp--
+

--- a/set-of-emails/maildir/bsd/rhost-apple-04.eml
+++ b/set-of-emails/maildir/bsd/rhost-apple-04.eml
@@ -1,0 +1,74 @@
+Return-Path: <>
+X-Original-To: kijitora@example.jp
+Received: from smtp1.example.jp (mailhub-2 [2.0.2.26])
+	by mail1.example.jp (Postfix) with ESMTPS id rz7w4SzXC0zCQrH5
+	for <kijitora@example.jp>; Thu, 29 Apr 2022 23:34:45 +0900 (JST)
+Received: by smtp1.example.jp (Postfix)
+	id HM1lQ7cLSMzNRChy; Thu, 29 Apr 2022 23:34:45 +0900 (JST)
+Date: Thu, 29 Apr 2022 23:34:45 +0900 (JST)
+From: MAILER-DAEMON@smtp1.example.jp (Mail Delivery System)
+To: kijitora@example.jp
+Message-Id: <HM1lQ7cLSMzNRChy@smtp1.example.jp>
+Subject: Undelivered Mail Returned to Sender
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="Hk664bT3pXznnDPw.1513619090/smtp1.example.jp"
+
+This is a MIME-encapsulated message.
+
+--Hk664bT3pXznnDPw.1513619090/smtp1.example.jp
+Content-Description: Notification
+Content-Type: text/plain; charset=us-ascii
+
+This is the mail system at host smtp1.example.jp.
+
+I'm sorry to have to inform you that your message could not
+be delivered to one or more recipients. It's attached below.
+
+For further assistance, please send mail to postmaster.
+
+If you do so, please include this problem report. You can
+delete your own text from the attached returned message.
+
+                   The mail system
+
+<pseudo-local-part-of-icloud@icloud.com>: host mx1.mail.icloud.com[17.172.34.9] said: 550
+    5.1.1 <pseudo-local-part-of-icloud@icloud.com>: inactive email address (in reply to RCPT
+    TO command)
+
+--Hk664bT3pXznnDPw.1513619090/smtp1.example.jp
+Content-Description: Delivery report
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; smtp1.example.jp
+X-Postfix-Queue-ID: Hk664bT3pXznnDPw
+X-Postfix-Sender: RFC822; kijitora@example.jp
+Arrival-Date: Thu, 29 Apr 2022 23:34:45 +0900 (JST)
+
+Final-Recipient: RFC822; pseudo-local-part-of-icloud@icloud.com
+Original-Recipient: RFC822;pseudo-local-part-of-icloud@icloud.com
+Action: failed
+Status: 5.1.1
+Remote-MTA: dns; mx.mail.icloud.com
+Diagnostic-Code: smtp; 550 5.1.1 <pseudo-local-part-of-icloud@icloud.com>: inactive email
+    address
+
+--Hk664bT3pXznnDPw.1513619090/smtp1.example.jp
+Content-Description: Undelivered Message
+Content-Type: message/rfc822
+
+Return-Path: <kijitora@example.jp>
+Received: from MAILHUB-1 (unknown [192.0.2.25])
+	by smtp1.example.jp (Postfix) with ESMTP id Hk664bT3pXznnDPw
+	for <pseudo-local-part-of-icloud@icloud.com>; Thu, 29 Apr 2022 23:34:45 +0900 (JST)
+MIME-Version: 1.0
+From: <kijitora@example.jp>
+To: <pseudo-local-part-of-icloud@icloud.com>
+Date: 29 Apr 2022 23:34:45 +0900
+Message-Id: <Hk664bT3pXznnDPw@smtp1.example.jp>
+Content-Type: text/plain; charset=us-ascii
+Subject: Nyaan?
+
+Nyaan?
+
+--Hk664bT3pXznnDPw.1513619090/smtp1.example.jp--

--- a/set-of-emails/maildir/bsd/rhost-yahooinc-01.eml
+++ b/set-of-emails/maildir/bsd/rhost-yahooinc-01.eml
@@ -1,0 +1,80 @@
+Return-Path: <>
+Received: from mbox.example.jp (mail.example.jp [192.0.2.48])
+	by mx.example.jp (V8/cf) with ESMTP id 0AD0mYaG000334
+	for <postmaster@example.jp>; Fri, 13 Nov 2020 09:48:34 +0900
+Received: from mbox.example.jp (localhost [127.0.0.1])
+	by mbox.example.jp (Postfix) with ESMTP id 4CXKb61hkLz22xZY
+	for <postmaster@sisimai.example.com>; Fri, 13 Nov 2020 09:48:34 +0900 (JST)
+Received: from smtp.example.jp (smtp.example.jp [203.0.113.113])
+	by mbox.example.jp (Postfix) with ESMTP id 4CXKb61FPyz1yM4D
+	for <postmaster@sisimai.example.com>; Fri, 13 Nov 2020 09:48:34 +0900 (JST)
+Received: by smtp.example.jp (Postfix)
+	id 056C3D244EC; Fri, 13 Nov 2020 09:48:34 +0900 (JST)
+Date: Fri, 13 Nov 2020 09:48:34 +0900 (JST)
+From: MAILER-DAEMON@smtp.example.jp (Mail Delivery System)
+Subject: Undelivered Mail Returned to Sender
+To: postmaster@sisimai.example.com
+Auto-Submitted: auto-replied
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="08513C0196A.1605228514/smtp.example.jp"
+Message-Id: <20201113004834.056C3D244EC@smtp.example.jp>
+X-Virus-Scanned: ClamAV using ClamSMTP
+
+This is a MIME-encapsulated message.
+
+--08513C0196A.1605228514/smtp.example.jp
+Content-Description: Notification
+Content-Type: text/plain; charset=us-ascii
+
+This is the mail system at host smtp.example.jp.
+
+I'm sorry to have to inform you that your message could not
+be delivered to one or more recipients. It's attached below.
+
+For further assistance, please send mail to postmaster.
+
+If you do so, please include this problem report. You can
+delete your own text from the attached returned message.
+
+                   The mail system
+
+ <kijitora@aol.example.jp>: host mx-aol.mail.gm0.yahoodns.net[67.195.204.80] said:
+    554 5.7.9 Message not accepted for policy reasons. See
+    https://postmaster.verizonmedia.com/error-codes (in reply to end of DATA
+    command)
+
+--08513C0196A.1605228514/smtp.example.jp
+Content-Description: Delivery report
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; smtp.example.jp
+X-Postfix-Queue-ID: 08513C0196A
+X-Postfix-Sender: rfc822; postmaster@sisimai.example.com
+Arrival-Date: Fri, 13 Nov 2020 09:47:59 +0900 (JST)
+
+Final-Recipient: rfc822; kijitora@aol.example.jp
+Original-Recipient: rfc822;kijitora@aol.example.jp
+Action: failed
+Status: 5.7.9
+Remote-MTA: dns; mx-aol.mail.gm0.yahoodns.net
+Diagnostic-Code: smtp; 554 5.7.9 Message not accepted for policy reasons. See
+    https://postmaster.verizonmedia.com/error-codes
+
+--08513C0196A.1605228514/smtp.example.jp
+Content-Description: Undelivered Message
+Content-Type: message/rfc822
+
+Return-Path: <postmaster@sisimai.example.com>
+Received: from [127.0.0.1] (localhost [127.0.0.1])
+	by smtp.example.jp (Postfix) with ESMTP id 08513C0196A
+	for <kijitora@aol.example.jp>; Fri, 13 Nov 2020 09:47:59 +0900 (JST)
+From: postmaster@libsisimai.org
+Subject: TEST FOR DMARC #7
+To: kijitora@aol.example.jp
+Message-Id: <20201113004812.08513C0196A@smtp.example.jp>
+Date: Fri, 13 Nov 2020 09:47:59 +0900 (JST)
+
+Nyaan
+
+--08513C0196A.1605228514/smtp.example.jp--

--- a/set-of-emails/maildir/bsd/rhost-yahooinc-02.eml
+++ b/set-of-emails/maildir/bsd/rhost-yahooinc-02.eml
@@ -1,0 +1,83 @@
+Return-Path: <>
+Delivered-To: deadbeef@mailmagazine.example.com
+Received: from u1.em.example.jp
+	by mbox3.em.example.jp with LMTP id pRi6D904298QQXvAukD22R
+	for <deadbeef@mailmagazine.example.com>; Tue, 17 Nov 2020 23:34:45 +0900
+Received: by u1.em.example.jp (Postfix)
+	id 9UKnCx1J50z3ZQ2; Tue, 17 Nov 2020 23:34:45 +0900 (JST)
+Date: Tue, 17 Nov 2020 23:34:45 +0900 (JST)
+From: MAILER-DAEMON@u1.em.example.jp (Mail Delivery System)
+Subject: Undelivered Mail Returned to Sender
+To: deadbeef@mailmagazine.example.com
+Auto-Submitted: auto-replied
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="9UK8Prr4eZzSPQR.1605555025/u1.em.example.jp"
+Message-Id: <9UKnCx1J50z3ZQ2@u1.em.example.jp>
+
+This is a MIME-encapsulated message.
+
+--9UK8Prr4eZzSPQR.1605555025/u1.em.example.jp
+Content-Description: Notification
+Content-Type: text/plain; charset=us-ascii
+
+This is the mail system at host u1.em.example.jp.
+
+I'm sorry to have to inform you that your message could not
+be delivered to one or more recipients. It's attached below.
+
+For further assistance, please send mail to postmaster.
+
+If you do so, please include this problem report. You can
+delete your own text from the attached returned message.
+
+                   The mail system
+
+<kijitora@y.example.ca>: host mta6.am0.yahoodns.net[67.195.204.72] said: 421
+    4.7.0 [TSS04] Messages from 192.0.2.192 temporarily deferred due to
+    unexpected volume or user complaints - 4.16.55.1; see
+    https://postmaster.verizonmedia.com/error-codes (in reply to MAIL FROM
+    command)
+
+--9UK8Prr4eZzSPQR.1605555025/u1.em.example.jp
+Content-Description: Delivery report
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; u1.em.example.jp
+X-Postfix-Queue-ID: 9UK8Prr4eZzSPQR
+X-Postfix-Sender: rfc822; deadbeef@mailmagazine.example.com
+Arrival-Date: Mon, 16 Nov 2020 23:34:45 +0900 (JST)
+
+Final-Recipient: rfc822; kijitora@y.example.ca
+Original-Recipient: rfc822;kijitora@y.example.ca
+Action: failed
+Status: 4.7.0
+Remote-MTA: dns; mta6.am0.yahoodns.net
+Diagnostic-Code: smtp; 421 4.7.0 [TSS04] Messages from 192.0.2.192
+    temporarily deferred due to unexpected volume or user complaints -
+    4.16.55.1; see https://postmaster.verizonmedia.com/error-codes
+
+--9UK8Prr4eZzSPQR.1605555025/u1.em.example.jp
+Content-Description: Undelivered Message
+Content-Type: message/rfc822
+
+Return-Path: <deadbeef@mailmagazine.example.com>
+Received: from u1.em.example.jp (localhost [127.0.0.1])
+	by u1.em.example.jp (Postfix) with ESMTP id 9UK8Prr4eZzSPQR
+	for <kijitora@y.example.ca>; Mon, 16 Nov 2020 23:34:45 +0900 (JST)
+Received: from localhost (localhost [127.0.0.1])
+	by u1.em.example.jp (Postfix) with ESMTP id 9UK8P757b8z3ZQM
+	for <kijitora@y.example.ca>; Mon, 16 Nov 2020 23:34:45 +0900 (JST)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=ISO-2022-JP
+Content-Transfer-Encoding: quoted-printable
+From: <neko@mailmagazine.example.com>
+To: "Kijitora" <kijitora@y.example.ca>
+Subject: Nyaan
+Message-Id: <9UK8P757b8z3ZQM@u1.em.example.jp>
+Date: Mon, 16 Nov 2020 23:34:45 +0900 (JST)
+X-Virus-Scanned: ClamAV using ClamSMTP
+
+Nyaan
+
+--9UK8Prr4eZzSPQR.1605555025/u1.em.example.jp--

--- a/set-of-emails/maildir/bsd/rhost-yahooinc-03.eml
+++ b/set-of-emails/maildir/bsd/rhost-yahooinc-03.eml
@@ -1,0 +1,125 @@
+Return-Path: <>
+Received: from mx2.example.jp (mx2.example.jp [192.0.2.222])
+	by aneyakoji.example.co.jp (V8/cf) with ESMTP id u8CJoVRB027731
+	for <postmaster@example.co.jp>; Tue, 13 Sep 2016 04:50:33 +0900
+X-SenderID: Sendmail Sender-ID Filter v1.0.0 aneyakoji.example.co.jp u8CJoVRB027731
+Authentication-Results: aneyakoji.example.co.jp; sender-id=none header.from=MAILER-DAEMON@mx2.example.jp
+Received: from localhost (localhost)
+	by mx2.example.jp (V8/cf) id u8CJoQN4016081;
+	Tue, 13 Sep 2016 04:50:33 +0900
+Date: Tue, 13 Sep 2016 04:50:33 +0900
+From: Mail Delivery Subsystem <MAILER-DAEMON@mx2.example.jp>
+Message-Id: <201609121950.u8CJoQN4016081@mx2.example.jp>
+To: postmaster@mx2.example.jp
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="u8CJoQN4016081.1473709833/mx2.example.jp"
+Subject: Postmaster notify: see transcript for details
+Auto-Submitted: auto-generated (postmaster-notification)
+
+This is a MIME-encapsulated message
+
+--u8CJoQN4016081.1473709833/mx2.example.jp
+
+The original message was received at Tue, 13 Sep 2016 04:50:26 +0900
+from localhost
+with id u8CJoQN3016081
+
+   ----- The following addresses had permanent fatal errors -----
+<this-local-part-does-not-exist@yahoo.com>
+    (reason: 554 delivery error: dd This user doesn't have a yahoo.com account (this-local-part-does-not-exist@yahoo.com) [0] - mta1061.mail.ne1.yahoo.com)
+
+   ----- Transcript of session follows -----
+... while talking to mta6.am0.yahoodns.net.:
+>>> DATA
+<<< 554 delivery error: dd This user doesn't have a yahoo.com account (this-local-part-does-not-exist@yahoo.com) [0] - mta1061.mail.ne1.yahoo.com
+554 5.0.0 Service unavailable
+
+--u8CJoQN4016081.1473709833/mx2.example.jp
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; mx2.example.jp
+Received-From-MTA: DNS; FF00FFFF.static.example.org
+Arrival-Date: Tue, 13 Sep 2016 04:50:26 +0900
+
+Final-Recipient: RFC822; this-local-part-does-not-exist@yahoo.com
+Action: failed
+Status: 5.0.0
+Remote-MTA: DNS; mta6.am0.yahoodns.net
+Diagnostic-Code: SMTP; 554 delivery error: dd This user doesn't have a yahoo.com account (this-local-part-does-not-exist@yahoo.com) [0] - mta1061.mail.ne1.yahoo.com
+Last-Attempt-Date: Tue, 13 Sep 2016 04:50:30 +0900
+
+--u8CJoQN4016081.1473709833/mx2.example.jp
+Content-Type: message/rfc822
+
+Return-Path: <MAILER-DAEMON>
+Received: from localhost (localhost)
+	by mx2.example.jp (V8/cf) id u8CJoQN3016081;
+	Tue, 13 Sep 2016 04:50:26 +0900
+Date: Tue, 13 Sep 2016 04:50:26 +0900
+From: Mail Delivery Subsystem <MAILER-DAEMON>
+Message-Id: <201609121950.u8CJoQN3016081@mx2.example.jp>
+To: <this-local-part-does-not-exist@yahoo.com>
+To: postmaster
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="u8CJoQN3016081.1473709826/mx2.example.jp"
+Subject: Returned mail: see transcript for details
+Auto-Submitted: auto-generated (failure)
+
+This is a MIME-encapsulated message
+
+--u8CJoQN3016081.1473709826/mx2.example.jp
+
+...
+
+--u8CJoQN3016081.1473709826/mx2.example.jp
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; mx2.example.jp
+Received-From-MTA: DNS; FF00FFFF.static.example.org
+Arrival-Date: Tue, 13 Sep 2016 04:50:25 +0900
+
+Original-Recipient: rfc822;kijitora@neko.example.com
+Final-Recipient: RFC822; kijitora@neko.example.com
+Action: failed
+Status: 5.3.5
+Diagnostic-Code: SMTP; 553 5.3.5 system config error
+Last-Attempt-Date: Tue, 13 Sep 2016 04:50:26 +0900
+
+--u8CJoQN3016081.1473709826/mx2.example.jp
+Content-Type: message/rfc822
+
+Return-Path: <this-local-part-does-not-exist@yahoo.com>
+Received: from mx.smtp.example.net (FF00FFFF.static.example.org [198.51.100.22])
+	by mx2.example.jp (V8/cf) with ESMTP id u8CJoPN3016079
+	for <kijitora@neko.example.com>; Tue, 13 Sep 2016 04:50:25 +0900
+Message-Id: <201609121950.u8CJoPN3016079@mx2.example.jp>
+Received: from User (unknown [203.0.113.2])
+	(Authenticated sender: server)
+	by mx.smtp.example.net (Postfix) with ESMTPA id 23EC336A7E;
+	Mon, 12 Sep 2016 13:35:38 +0200 (CEST)
+Reply-To: <sironeko@example.ad.jp>
+From: "NON-EXISTENT" <this-local-part-does-not-exist@yahoo.com>
+Subject: Nyaan
+Date: Mon, 12 Sep 2016 13:35:46 +0200
+MIME-Version: 1.0
+Content-Type: text/html;
+	charset="Windows-1251"
+Content-Transfer-Encoding: 7bit
+X-Priority: 3
+X-MSMail-Priority: Normal
+X-Mailer: Microsoft Outlook Express 6.00.2600.0000
+X-MimeOLE: Produced By Microsoft MimeOLE V6.00.2600.0000
+To: undisclosed-recipients:;
+
+<HTML><HEAD><TITLE></TITLE>
+</HEAD>
+<BODY bgcolor=#FFFFFF leftmargin=5 topmargin=5 rightmargin=5 bottommargin=5>
+</BODY></HTML>
+
+--u8CJoQN3016081.1473709826/mx2.example.jp--
+
+
+--u8CJoQN4016081.1473709833/mx2.example.jp--
+

--- a/test/private/lhost-postfix.rb
+++ b/test/private/lhost-postfix.rb
@@ -240,7 +240,7 @@ module LhostEngineTest::Private
       '01231' => [['5.7.9',   '550', 'policyviolation', false],
                   ['5.7.1',   '550', 'authfailure',     false],
                   ['5.7.1',   '550', 'authfailure',     false]],
-      '01232' => [['4.7.0',   '421', 'blocked',         false]],
+      '01232' => [['4.7.0',   '421', 'badreputation',   false]],
       '01233' => [['5.0.0',   '550', 'blocked',         false]],
       '01234' => [['5.0.0',   '553', 'rejected',        false]],
       '01235' => [['5.0.0',   '554', 'spamdetected',    false]],

--- a/test/private/lhost-sendmail.rb
+++ b/test/private/lhost-sendmail.rb
@@ -40,7 +40,7 @@ module LhostEngineTest::Private
       '01034' => [['5.3.0',   '554', 'mailererror',     false]],
       '01035' => [['5.1.1',   '503', 'userunknown',     true]],
       '01036' => [['5.0.0',   '554', 'filtered',        false]],
-      '01037' => [['5.0.0',   '554', 'filtered',        false]],
+      '01037' => [['5.0.0',   '554', 'userunknown',     true]],
       '01038' => [['5.1.1',   '550', 'userunknown',     true]],
       '01039' => [['5.2.1',   '550', 'filtered',        false],
                   ['5.1.1',   '550', 'userunknown',     true]],

--- a/test/public/lhost-postfix.rb
+++ b/test/public/lhost-postfix.rb
@@ -67,7 +67,7 @@ module LhostEngineTest::Public
       '71' => [['5.7.1',   '554', 'authfailure',     false]],
       '72' => [['5.7.1',   '550', 'authfailure',     false]],
       '73' => [['5.7.1',   '550', 'authfailure',     false]],
-      '74' => [['4.7.0',   '421', 'blocked',         false]],
+      '74' => [['4.7.0',   '421', 'badreputation',   false]],
       '75' => [['4.3.0',   '451', 'systemerror',     false]],
       '76' => [['5.0.0',   '550', 'userunknown',     true]],
       '77' => [['5.0.0',   '554', 'norelaying',      false]],

--- a/test/public/lhost-sendmail.rb
+++ b/test/public/lhost-sendmail.rb
@@ -43,7 +43,7 @@ module LhostEngineTest::Public
       '38' => [['5.7.1',   '550', 'spamdetected',    false]],
       '39' => [['4.4.5',   '452', 'systemfull',      false]],
       '40' => [['5.2.0',   '550', 'filtered',        false]],
-      '41' => [['5.0.0',   '554', 'filtered',        false]],
+      '41' => [['5.0.0',   '554', 'userunknown',     true]],
       '42' => [['5.1.2',   '550', 'hostunknown',     true]],
       '43' => [['5.7.1',   '550', 'notcompliantrfc', false]],
       '44' => [['5.6.0',   '552', 'contenterror',    false]],

--- a/test/public/mail-maildir-test.rb
+++ b/test/public/mail-maildir-test.rb
@@ -5,7 +5,7 @@ class MailMaildirTest < Minitest::Test
   Methods = { class: %w[new], object: %w[path dir file size handle offset read] }
   Samples = ['./set-of-emails/maildir/bsd', './set-of-emails/maildir/mac']
   Maildir = Sisimai::Mail::Maildir.new(Samples[0])
-  DirSize = 531
+  DirSize = 538
 
   def test_methods
     Methods[:class].each  { |e| assert_respond_to Sisimai::Mail::Maildir, e }

--- a/test/public/rhost-apple.rb
+++ b/test/public/rhost-apple.rb
@@ -1,0 +1,12 @@
+module RhostEngineTest::Public
+  module Apple
+    IsExpected = {
+      # INDEX => [['D.S.N.', 'replycode', 'REASON', 'hardbounce'], [...]]
+      '01' => [['5.1.6',   '550', 'hasmoved',        true]],
+      '02' => [['5.7.1',   '554', 'authfailure',     false]],
+      '03' => [['5.2.2',   '552', 'mailboxfull',     false]],
+      '04' => [['5.1.1',   '550', 'userunknown',     true]],
+    }
+  end
+end
+

--- a/test/public/rhost-engine-test.rb
+++ b/test/public/rhost-engine-test.rb
@@ -15,7 +15,10 @@ module RhostEngineTest
       emailindex = ARGV[1] || 0
 
       # % grep -h module lib/sisimai/rhost/*.rb | grep -vE '(Sisimai|Rhost)' | awk '{ print $2 }'
-      rhostindex = %w[Cox FrancePTT GoDaddy Google IUA KDDI Microsoft Mimecast NTTDOCOMO Spectrum Tencent]
+      rhostindex = %w[
+        Apple Cox FrancePTT GoDaddy Google IUA KDDI Microsoft Mimecast NTTDOCOMO Spectrum Tencent
+        YahooInc
+      ]
       enginelist = []
       enginename = ''
 

--- a/test/public/rhost-yahooinc.rb
+++ b/test/public/rhost-yahooinc.rb
@@ -1,0 +1,11 @@
+module RhostEngineTest::Public
+  module YahooInc
+    IsExpected = {
+      # INDEX => [['D.S.N.', 'replycode', 'REASON', 'hardbounce'], [...]]
+      '01' => [['5.7.9',   '554', 'policyviolation', false]],
+      '02' => [['4.7.0',   '421', 'badreputation',   false]],
+      '03' => [['5.0.0',   '554', 'userunknown',     true]],
+    }
+  end
+end
+


### PR DESCRIPTION
- #288
- Consolidate error messages scattered under `Sisimai::Reason::*` into `Sisimai::Rhost::*`  classes for each email service
- `Sisimai::Rhost::YahooInc` for https://senders.yahooinc.com/smtp-error-codes/
  - The following sample emails in `set-of-emails/maildir/bsd`:
    - `rhost-yahooinc-01.eml`
    - `rhost-yahooinc-02.eml`
    - `rhost-yaoooinc-03.eml`
- `Sisimai::Rhost::Apple` for iCloud Mail
  - The following sample emails in `set-of-emails/maildir/bsd`:
    - `rhost-apple-01.eml`
    - `rhost-apple-02.eml`
    - `rhost-apple-03.eml`
    - `rhost-apple-04.eml`