### PR TITLE
go-sisimai compatibility 7e89

### DIFF
--- a/lib/sisimai/fact.rb
+++ b/lib/sisimai/fact.rb
@@ -388,7 +388,7 @@ module Sisimai
         if thing['reason'].empty? || RetryIndex[thing['reason']]
           # The value of "reason" is empty or is needed to check with other values again
           re = thing['reason'].empty? ? 'undefined' : thing['reason']
-          thing['reason'] = Sisimai::Rhost.get(thing) || Sisimai::Reason.get(thing)
+          thing['reason'] = Sisimai::Rhost.find(thing) || Sisimai::Reason.get(thing)
           thing['reason'] = re if thing['reason'].empty?
         end
 

--- a/lib/sisimai/fact.rb
+++ b/lib/sisimai/fact.rb
@@ -400,17 +400,17 @@ module Sisimai
           # The reason is not "delivered", or "feedback", or "vacation"
           smtperrors = piece['deliverystatus'] + ' ' << piece['diagnosticcode']
           smtperrors = '' if smtperrors.size < 4
-          softorhard = Sisimai::SMTP::Failure.soft_or_hard(thing['reason'], smtperrors)
-          thing['hardbounce'] = true if softorhard == 'hard'
+          thing['hardbounce'] = Sisimai::SMTP::Failure.is_hardbounce(thing['reason'], smtperrors)
         end
 
         # DELIVERYSTATUS: Set a pseudo status code if the value of "deliverystatus" is empty
         if thing['deliverystatus'].empty?
           smtperrors = piece['replycode'] + ' ' << piece['diagnosticcode']
           smtperrors = '' if smtperrors.size < 4
-          permanent1 = Sisimai::SMTP::Failure.is_permanent(smtperrors)
-          permanent1 = true if permanent1 == nil
-          thing['deliverystatus'] = Sisimai::SMTP::Status.code(thing['reason'], permanent1 ? false : true) || ''
+          permanent0 = Sisimai::SMTP::Failure.is_permanent(smtperrors)
+          temporary0 = Sisimai::SMTP::Failure.is_temporary(smtperrors)
+          temporary1 = temporary0; temporary1 = false if !permanent0 && !temporary1 
+          thing['deliverystatus'] = Sisimai::SMTP::Status.code(thing['reason'], temporary1) || ''
         end
 
         # REPLYCODE: Check both of the first digit of "deliverystatus" and "replycode"

--- a/lib/sisimai/fact.rb
+++ b/lib/sisimai/fact.rb
@@ -8,7 +8,7 @@ module Sisimai
     require 'sisimai/address'
     require 'sisimai/datetime'
     require 'sisimai/time'
-    require 'sisimai/smtp/error'
+    require 'sisimai/smtp/failure'
     require 'sisimai/smtp/command'
     require 'sisimai/string'
     require 'sisimai/rhost'
@@ -400,7 +400,7 @@ module Sisimai
           # The reason is not "delivered", or "feedback", or "vacation"
           smtperrors = piece['deliverystatus'] + ' ' << piece['diagnosticcode']
           smtperrors = '' if smtperrors.size < 4
-          softorhard = Sisimai::SMTP::Error.soft_or_hard(thing['reason'], smtperrors)
+          softorhard = Sisimai::SMTP::Failure.soft_or_hard(thing['reason'], smtperrors)
           thing['hardbounce'] = true if softorhard == 'hard'
         end
 
@@ -408,7 +408,7 @@ module Sisimai
         if thing['deliverystatus'].empty?
           smtperrors = piece['replycode'] + ' ' << piece['diagnosticcode']
           smtperrors = '' if smtperrors.size < 4
-          permanent1 = Sisimai::SMTP::Error.is_permanent(smtperrors)
+          permanent1 = Sisimai::SMTP::Failure.is_permanent(smtperrors)
           permanent1 = true if permanent1 == nil
           thing['deliverystatus'] = Sisimai::SMTP::Status.code(thing['reason'], permanent1 ? false : true) || ''
         end

--- a/lib/sisimai/lhost/exim.rb
+++ b/lib/sisimai/lhost/exim.rb
@@ -381,7 +381,7 @@ module Sisimai::Lhost
 
             if e['diagnosis'].start_with?('-') || e['diagnosis'].end_with?('__')
               # Override the value of diagnostic code message
-              e['diagnosis'] = e['alterrors'] unless e['alterrors'].empty?
+              e['diagnosis'] = e['alterrors']
 
             elsif e['diagnosis'].size < e['alterrors'].size
               # Override the value of diagnostic code message with the value of alterrors because

--- a/lib/sisimai/lhost/exim.rb
+++ b/lib/sisimai/lhost/exim.rb
@@ -448,47 +448,21 @@ module Sisimai::Lhost
           #
           # The value of "Status:" indicates permanent error but the value of SMTP reply code in
           # Diagnostic-Code: field is "TEMPERROR"!!!!
-          cs = e['status']    || Sisimai::SMTP::Status.find(e['diagnosis'])
-          cr = e['replycode'] || Sisimai::SMTP::Reply.find(e['diagnosis'])
-          s1 = 0  # First character of Status as integer
-          r1 = 0  # First character of SMTP reply code as integer
+          re = e['reason'] || ''
+          cr = Sisimai::SMTP::Reply.find(e['diagnosis'], e['status'] || '') || ''
+          cs = Sisimai::SMTP::Status.find(e['diagnosis'], cr)
+          cv = ''
 
-          while true
-            # "Status:" field did not exist in the bounce message
-            break if cs
-            break unless cr
+          if cr[0,1] == "4" || re == "expired" || re == "mailboxfull"
+            # Set the pseudo status code as a temporary error
+            cv = Sisimai::SMTP::Status.code(re, true)
 
-            # Check SMTP reply code, Generate pseudo DSN code from SMTP reply code
-            r1 = cr[0, 1].to_i
-            if r1 == 4
-              # Get the internal DSN(temporary error)
-              cs = Sisimai::SMTP::Status.code(e['reason'], true)
-
-            elsif r1 == 5
-              # Get the internal DSN(permanent error)
-              cs = Sisimai::SMTP::Status.code(e['reason'], false)
-            end
-            break
-          end
-
-          s1 = cs[0, 1].to_i if cs
-          v1 = s1 + r1
-          v1 << e['status'][0, 1].to_i if e['status']
-
-          if v1 > 0
-            # Status or SMTP reply code exists, Set pseudo DSN into the value of "status" accessor
-            e['status'] = cs if r1 > 0
           else
-            # Neither Status nor SMTP reply code exist
-            cs = if %w[expired mailboxfull].include?(e['reason'])
-                   # Set pseudo DSN (temporary error)
-                   Sisimai::SMTP::Status.code(e['reason'], true)
-                 else
-                   # Set pseudo DSN (permanent error)
-                   Sisimai::SMTP::Status.code(e['reason'], false)
-                 end
+            # Set the pseudo status code as a permanent error
+            cv = Sisimai::SMTP::Status.code(re, false)
           end
-          e['status'] ||= cs.to_s
+          e['replycode'] ||= cr
+          e['status']    ||= Sisimai::SMTP::Status.prefer(cs, cv, cr)
         end
 
         return { 'ds' => dscontents, 'rfc822' => emailparts[1] }

--- a/lib/sisimai/reason/badreputation.rb
+++ b/lib/sisimai/reason/badreputation.rb
@@ -19,6 +19,7 @@ module Sisimai
           'has been temporarily rate limited due to ip reputation',
           'ip/domain reputation problems',
           'likely suspicious due to the very low reputation',
+          'none/bad reputation', # t-online.de
           'temporarily deferred due to unexpected volume or user complaints', # Yahoo Inc.
           "the sending mta's poor reputation",
         ].freeze

--- a/lib/sisimai/rhost.rb
+++ b/lib/sisimai/rhost.rb
@@ -1,6 +1,6 @@
 module Sisimai
   # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
-  # of get() method when the value of rhost of the object is listed in the results of Sisimai::Rhost
+  # of find() method when the value of rhost of the object is listed in the results of Sisimai::Rhost
   # ->list method. This class is called only Sisimai::Fact class.
   module Rhost
     class << self
@@ -23,7 +23,7 @@ module Sisimai
       # Detect the bounce reason from certain remote hosts
       # @param    [Hash]   argvs  Decoded email data
       # @return   [String]        The value of bounce reason
-      def get(argvs)
+      def find(argvs)
         return nil if argvs['diagnosticcode'].empty?
 
         remotehost = argvs['rhost'].downcase
@@ -47,7 +47,7 @@ module Sisimai
         return nil if rhostclass.empty?
 
         require rhostclass
-        reasontext = Module.const_get(modulename).get(argvs)
+        reasontext = Module.const_get(modulename).find(argvs)
         return nil if reasontext.empty?
         return reasontext
       end

--- a/lib/sisimai/rhost.rb
+++ b/lib/sisimai/rhost.rb
@@ -37,7 +37,7 @@ module Sisimai
         RhostClass.each_key do |e|
           # Try to match with each value of RhostClass
           rhostmatch   = true if RhostClass[e].any? { |a| remotehost.end_with?(a) }
-          rhostmatch ||= true if RhostClass[e].any? { |a| domainpart.end_with?(a) }
+          rhostmatch ||= true if RhostClass[e].any? { |a| a.end_with?(domainpart) }
           next unless rhostmatch
 
           modulename = 'Sisimai::Rhost::' << e

--- a/lib/sisimai/rhost/apple.rb
+++ b/lib/sisimai/rhost/apple.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module Rhost
     # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
-    # of get() method when the value of "destination" of the object is "mail.icloud.com" or "apple.com".
+    # of find() method when the value of "destination" of the object is "mail.icloud.com" or "apple.com".
     # This class is called only Sisimai::Fact class.
     module Apple
       class << self
@@ -69,7 +69,7 @@ module Sisimai
         #           https://www.postmastery.com/icloud-postmastery-page/
         #           https://smtpfieldmanual.com/provider/apple
         # @since v5.1.0
-        def get(argvs)
+        def find(argvs)
           return '' unless argvs
           return '' unless argvs['diagnosticcode'].size > 0
 

--- a/lib/sisimai/rhost/apple.rb
+++ b/lib/sisimai/rhost/apple.rb
@@ -70,6 +70,9 @@ module Sisimai
         #           https://smtpfieldmanual.com/provider/apple
         # @since v5.1.0
         def get(argvs)
+          return '' unless argvs
+          return '' unless argvs['diagnosticcode'].size > 0
+
           issuedcode = argvs['diagnosticcode'].downcase
           reasontext = ''
 

--- a/lib/sisimai/rhost/cox.rb
+++ b/lib/sisimai/rhost/cox.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module Rhost
     # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
-    # of get() method when the value of "destination" of the object is "charter.net". This class is
+    # of find() method when the value of "destination" of the object is "charter.net". This class is
     # called only Sisimai::Fact class.
     module Cox
       class << self
@@ -129,7 +129,7 @@ module Sisimai
         # @return   [String, Nil]           The bounce reason at Cox
         # @see      https://www.cox.com/residential/support/email-error-codes.html
         # @since v4.25.8
-        def get(argvs)
+        def find(argvs)
           issuedcode = argvs['diagnosticcode']
           codenumber = 0
 

--- a/lib/sisimai/rhost/franceptt.rb
+++ b/lib/sisimai/rhost/franceptt.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module Rhost
     # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
-    # of get() method when the value of "rhost" of the object is "*.laposte.net" or "*.orange.fr".
+    # of find() method when the value of "rhost" of the object is "*.laposte.net" or "*.orange.fr".
     # This class is called only Sisimai::Fact class.
     module FrancePTT
       class << self
@@ -127,7 +127,7 @@ module Sisimai
         # @return   [String]                The bounce reason for Orange or La Poste
         # @see      https://www.postmastery.com/orange-postmaster-smtp-error-codes-ofr/
         #           https://smtpfieldmanual.com/provider/orange
-        def get(argvs)
+        def find(argvs)
           issuedcode = argvs['diagnosticcode']
           reasontext = ''
 

--- a/lib/sisimai/rhost/godaddy.rb
+++ b/lib/sisimai/rhost/godaddy.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module Rhost
     # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
-    # of get() method when the value of "rhost" of the object is "*.secureserver.net". This class is
+    # of find() method when the value of "rhost" of the object is "*.secureserver.net". This class is
     # called only Sisimai::Fact class.
     module GoDaddy
       class << self
@@ -206,7 +206,7 @@ module Sisimai
         # @return   [String]                The bounce reason for GoDaddy
         # @see      https://ca.godaddy.com/help/fix-rejected-email-with-a-bounce-error-40685
         # @since v4.22.2
-        def get(argvs)
+        def find(argvs)
           issuedcode = argvs['diagnosticcode']
           positionib = issuedcode.index(' IB') || -1
           reasontext = ''

--- a/lib/sisimai/rhost/google.rb
+++ b/lib/sisimai/rhost/google.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module Rhost
     # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
-    # of get() method when the value of "rhost" of the object is "aspmx.l.google.com". This class is
+    # of find() method when the value of "rhost" of the object is "aspmx.l.google.com". This class is
     # called only Sisimai::Fact class.
     module Google
       class << self
@@ -512,7 +512,7 @@ module Sisimai
         # @param    [Sisimai::Fact] argvs   Decoded email object
         # @return   [String]                The bounce reason for Google Workspace
         # @see      https://support.google.com/a/answer/3726730?hl=en
-        def get(argvs)
+        def find(argvs)
           return '' unless Sisimai::SMTP::Reply.test(argvs['replycode'])
           return '' unless Sisimai::SMTP::Status.test(argvs['deliverystatus'])
 

--- a/lib/sisimai/rhost/iua.rb
+++ b/lib/sisimai/rhost/iua.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module Rhost
     # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
-    # of get() method when the value of "rhost" of the object is "*.email.ua". This class is called
+    # of find() method when the value of "rhost" of the object is "*.email.ua". This class is called
     # only Sisimai::Fact class.
     module IUA
       class << self
@@ -22,7 +22,7 @@ module Sisimai
         # Detect bounce reason from https://www.i.ua/
         # @param    [Sisimai::Fact] argvs   Decoded email object
         # @return   [String]                The bounce reason at https://www.i.ua/
-        def get(argvs)
+        def find(argvs)
           return argvs['reason'] unless argvs['reason'].empty?
           issuedcode = argvs['diagnosticcode'].downcase
           codenumber = issuedcode.index('.i.ua/err/') > 0 ? issuedcode[issuedcode.index('/err/') + 5, 2] : 0

--- a/lib/sisimai/rhost/kddi.rb
+++ b/lib/sisimai/rhost/kddi.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module Rhost
     # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
-    # of get() method when the value of "rhost" of the object is "lsean.ezweb.ne.jp" or "msmx.au.com".
+    # of find() method when the value of "rhost" of the object is "lsean.ezweb.ne.jp" or "msmx.au.com".
     # This class is called only Sisimai::Fact class.
     module KDDI
       class << self
@@ -14,7 +14,7 @@ module Sisimai
         # @param    [Sisimai::Fact] argvs   Decoded email object
         # @return   [String]                The bounce reason for au.com or ezweb.ne.jp
         # @since v4.22.6
-        def get(argvs)
+        def find(argvs)
           issuedcode = argvs['diagnosticcode'].downcase
           reasontext = ''
 

--- a/lib/sisimai/rhost/microsoft.rb
+++ b/lib/sisimai/rhost/microsoft.rb
@@ -328,6 +328,7 @@ module Sisimai
           ],
           'notaccept' => [
             ['4.3.2', 0, 0, 'system not accepting network messages'],
+            ['4.4.4', 0, 0, 'hosted tenant which has no mail-enabled subscriptions'],
 
             # Exchange Server 2019 ----------------------------------------------------------------
             # - You're using the ABP Routing agent, and the recipient isn't a member of the global

--- a/lib/sisimai/rhost/microsoft.rb
+++ b/lib/sisimai/rhost/microsoft.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module Rhost
     # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
-    # of get() method when the value of "rhost" of the object is *.protection.outlook.com. This class
+    # of find() method when the value of "rhost" of the object is *.protection.outlook.com. This class
     # is called only Sisimai::Fact class.
     #
     # https://technet.microsoft.com/en-us/library/bb232118
@@ -715,7 +715,7 @@ module Sisimai
         # @param    [Sisimai::Fact] argvs   Decoded email object
         # @return   [String]                The bounce reason for Exchange Online
         # @since v4.17.2
-        def get(argvs)
+        def find(argvs)
           return '' if argvs['deliverystatus'].empty?
           return '' unless Sisimai::SMTP::Status.test(argvs['deliverystatus'])
 

--- a/lib/sisimai/rhost/mimecast.rb
+++ b/lib/sisimai/rhost/mimecast.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module Rhost
     # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argu-
-    # ment of get() method when the value of "rhost" of the object is "*.mimecast.com". This class
+    # ment of find() method when the value of "rhost" of the object is "*.mimecast.com". This class
     # is called only Sisimai::Fact class.
     module Mimecast
       class << self
@@ -281,7 +281,7 @@ module Sisimai
         # Detect bounce reason from Mimecast
         # @param    [Sisimai::Fact] argvs   Decoded email object
         # @return   [String]                The bounce reason for mimecast.com
-        def get(argvs)
+        def find(argvs)
           return '' unless Sisimai::SMTP::Reply.test(argvs['replycode'])
 
           issuedcode = argvs['diagnosticcode'].downcase || ''

--- a/lib/sisimai/rhost/nttdocomo.rb
+++ b/lib/sisimai/rhost/nttdocomo.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module Rhost
     # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
-    # of get() method when the value of "rhost" of the object is "mfsmax.docomo.ne.jp". This class
+    # of find() method when the value of "rhost" of the object is "mfsmax.docomo.ne.jp". This class
     # is called only Sisimai::Fact class.
     module NTTDOCOMO
       class << self
@@ -14,7 +14,7 @@ module Sisimai
         # Detect bounce reason from NTT DOCOMO
         # @param    [Sisimai::Fact] argvs   Decoded email object
         # @return   [String]                The bounce reason for docomo.ne.jp
-        def get(argvs)
+        def find(argvs)
           statuscode = argvs['deliverystatus']          || ''
           thecommand = argvs['smtpcommand']             || ''
           esmtperror = argvs['diagnosticcode'].downcase || ''

--- a/lib/sisimai/rhost/spectrum.rb
+++ b/lib/sisimai/rhost/spectrum.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module Rhost
     # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
-    # of get() method when the value of "destination" of the object is "charter.net". This class is
+    # of find() method when the value of "destination" of the object is "charter.net". This class is
     # called only Sisimai::Fact class.
     module Spectrum
       class << self
@@ -100,7 +100,7 @@ module Sisimai
         # @param    [Sisimai::Fact] argvs   Decoded email object
         # @return   [String, Nil]           The bounce reason at Spectrum
         # @since v4.25.8
-        def get(argvs)
+        def find(argvs)
           issuedcode = argvs['diagnosticcode']
           reasontext = ''
           codenumber = if cv = issuedcode.match(/AUP#[-A-Za-z]*(\d{4})/) then cv[1].to_i else 0 end

--- a/lib/sisimai/rhost/tencent.rb
+++ b/lib/sisimai/rhost/tencent.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module Rhost
     # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
-    # of get() method when the value of "rhost" of the object is "mx*.qq.com". This class is called
+    # of find() method when the value of "rhost" of the object is "mx*.qq.com". This class is called
     # only Sisimai::Fact class.
     module Tencent
       class << self
@@ -49,7 +49,7 @@ module Sisimai
         # Detect bounce reason from Tencent QQ
         # @param    [Sisimai::Fact] argvs   Decoded email object
         # @return   [String]                The bounce reason at Tencent QQ
-        def get(argvs)
+        def find(argvs)
           issuedcode = argvs['diagnosticcode'].downcase
           reasontext = ''
 

--- a/lib/sisimai/rhost/yahooinc.rb
+++ b/lib/sisimai/rhost/yahooinc.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module Rhost
     # Sisimai::Rhost detects the bounce reason from the content of Sisimai::Fact object as an argument
-    # of get() method when the value of "destination" of the object is "*.yahoodns.net".
+    # of find() method when the value of "destination" of the object is "*.yahoodns.net".
     # This class is called only Sisimai::Fact class.
     module YahooInc
       class << self
@@ -87,7 +87,7 @@ module Sisimai
         #           https://smtpfieldmanual.com/provider/yahoo
         #           https://www.postmastery.com/yahoo-postmaster/
         # @since v5.1.0
-        def get(argvs)
+        def find(argvs)
           issuedcode = argvs['diagnosticcode'].downcase
           reasontext = ''
 

--- a/lib/sisimai/smtp/failure.rb
+++ b/lib/sisimai/smtp/failure.rb
@@ -1,7 +1,7 @@
 module Sisimai
   module SMTP
-    # Sisimai::SMTP::Error is utilities for checking SMTP Errors from error message text.
-    module Error
+    # Sisimai::SMTP::Failure is utilities for checking SMTP Errors from error message text.
+    module Failure
       class << self
         require 'sisimai/smtp/reply'
         require 'sisimai/smtp/status'

--- a/test/private/lhost-sendgrid.rb
+++ b/test/private/lhost-sendgrid.rb
@@ -5,7 +5,7 @@ module LhostEngineTest::Private
       '01001' => [['5.1.1',   '550', 'userunknown',     true]],
       '01002' => [['5.1.1',   '550', 'userunknown',     true]],
       '01003' => [['5.0.947', '',    'expired',         false]],
-      '01004' => [['5.0.0',   '550', 'filtered',        false]],
+      '01004' => [['5.0.0',   '550', 'rejected',        false]],
       '01005' => [['5.2.1',   '550', 'userunknown',     true]],
       '01006' => [['5.2.2',   '550', 'mailboxfull',     false]],
       '01007' => [['5.1.1',   '550', 'userunknown',     true]],

--- a/test/public/lhost-code.rb
+++ b/test/public/lhost-code.rb
@@ -57,8 +57,8 @@ class LhostCode < Minitest::Test
       assert_respond_to currmodule, 'inquire'
 
     elsif modulename.include?('::Rhost::')
-      # Sisimai::Rhost::*.get
-      assert_respond_to currmodule, 'get'
+      # Sisimai::Rhost::*.find
+      assert_respond_to currmodule, 'find'
     end
 
     isexpected.keys.sort.each do |e|

--- a/test/public/rhost-test.rb
+++ b/test/public/rhost-test.rb
@@ -3,13 +3,13 @@ require 'sisimai/rhost'
 require 'sisimai'
 
 class RhostTest < Minitest::Test
-  Methods = { class:  %w[get] }
+  Methods = { class:  %w[find] }
 
   def test_methods
     Methods[:class].each { |e| assert_respond_to Sisimai::Rhost, e }
   end
 
-  def test_get
+  def test_find
     Dir.glob('./set-of-emails/maildir/bsd/rhost-*.eml').each do |e|
       cv = Sisimai.rise(e)
       assert_instance_of Array, cv
@@ -22,7 +22,7 @@ class RhostTest < Minitest::Test
         refute_empty ee.reason
         cx = ee.damn
 
-        cr = Sisimai::Rhost.get(cx)
+        cr = Sisimai::Rhost.find(cx)
         refute_empty cx['destination']
         refute_empty cr
         assert_equal cx['reason'], cr
@@ -31,8 +31,8 @@ class RhostTest < Minitest::Test
     end
 
     ce = assert_raises ArgumentError do
-      Sisimai::Rhost.get()
-      Sisimai::Rhost.get(nil, nil, nil)
+      Sisimai::Rhost.find()
+      Sisimai::Rhost.find(nil, nil, nil)
     end
   end
 end

--- a/test/public/smtp-failure-test.rb
+++ b/test/public/smtp-failure-test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
-require 'sisimai/smtp/error'
+require 'sisimai/smtp/failure'
 
-class SMTPError < Minitest::Test
+class SMTPFailure < Minitest::Test
   Methods = { class: %w[find] }
   Bounces = {
     soft: [
@@ -35,31 +35,31 @@ class SMTPError < Minitest::Test
   ]
 
   def test_is_permanent
-    WasSent.each { |e| assert_nil          Sisimai::SMTP::Error.is_permanent(e) }
-    TempErr.each { |e| assert_equal false, Sisimai::SMTP::Error.is_permanent(e) }
-    PermErr.each { |e| assert_equal true,  Sisimai::SMTP::Error.is_permanent(e) }
+    WasSent.each { |e| assert_nil          Sisimai::SMTP::Failure.is_permanent(e) }
+    TempErr.each { |e| assert_equal false, Sisimai::SMTP::Failure.is_permanent(e) }
+    PermErr.each { |e| assert_equal true,  Sisimai::SMTP::Failure.is_permanent(e) }
 
     ce = assert_raises ArgumentError do
-      Sisimai::SMTP::Error.is_permanent()
-      Sisimai::SMTP::Error.is_permanent(nil, nil)
+      Sisimai::SMTP::Failure.is_permanent()
+      Sisimai::SMTP::Failure.is_permanent(nil, nil)
     end
-    assert_nil Sisimai::SMTP::Error.is_permanent(nil)
+    assert_nil Sisimai::SMTP::Failure.is_permanent(nil)
   end
 
   def test_soft_or_hard
-    Bounces[:soft].each { |e| assert_equal 'soft', Sisimai::SMTP::Error.soft_or_hard(e) }
+    Bounces[:soft].each { |e| assert_equal 'soft', Sisimai::SMTP::Failure.soft_or_hard(e) }
     Bounces[:hard].each do |e|
-      assert_equal 'hard', Sisimai::SMTP::Error.soft_or_hard(e)
-      assert_equal 'hard', Sisimai::SMTP::Error.soft_or_hard(e, '503 Not accept any email') if e == 'notaccept'
-      assert_equal 'soft', Sisimai::SMTP::Error.soft_or_hard(e, '458 Not accept any email') if e == 'notaccept'
+      assert_equal 'hard', Sisimai::SMTP::Failure.soft_or_hard(e)
+      assert_equal 'hard', Sisimai::SMTP::Failure.soft_or_hard(e, '503 Not accept any email') if e == 'notaccept'
+      assert_equal 'soft', Sisimai::SMTP::Failure.soft_or_hard(e, '458 Not accept any email') if e == 'notaccept'
     end
-    NoError.each { |e| assert_equal '', Sisimai::SMTP::Error.soft_or_hard(e) }
+    NoError.each { |e| assert_equal '', Sisimai::SMTP::Failure.soft_or_hard(e) }
 
     ce = assert_raises ArgumentError do
-      Sisimai::SMTP::Error.soft_or_hard()
-      Sisimai::SMTP::Error.soft_or_hard(nil, nil, nil)
+      Sisimai::SMTP::Failure.soft_or_hard()
+      Sisimai::SMTP::Failure.soft_or_hard(nil, nil, nil)
     end
-    assert_nil Sisimai::SMTP::Error.soft_or_hard(nil)
+    assert_nil Sisimai::SMTP::Failure.soft_or_hard(nil)
   end
 
 end


### PR DESCRIPTION
- `Sisimai::SMTP::Error` has been renamed to `Sisimai::SMTP::Failure` and the following methods implemented:
  - `is_temporary()`
  - `is_hardbounce()`
  - `is_softbounce()`
  - `soft_or_hard()` has been removed
- Changes in `Sisimai::Rhost` 
  - `get()` method has been renamed to `find()`
  - Fix bug in code to check the domain part of an email address as a remote hostname
  - Add `['4.4.4', 0, 0, 'hosted tenant which has no mail-enabled subscriptions'` in `Sisimai::Rhost::Microsoft`
- Code improvement and bug fix at `Sisimai::Lhost::Exim`
  - Remove needless condition for getting error messages
  - Rewrite code for getting an SMTP reply code and a delivery status code
- Add a new error message pattern in `Sisimai::Reason::BadReputation`