### PR TITLE
Fix #361 (Encoding problem) reported by @timoschilling

### DIFF
--- a/lib/sisimai/rfc2045.rb
+++ b/lib/sisimai/rfc2045.rb
@@ -346,6 +346,8 @@ module Sisimai
 
           else
             # There is no Content-Transfer-Encoding header in the part
+            be = bodyinside.encoding.to_s
+            bodyinside  = Sisimai::String.to_utf8(bodyinside, be) unless be == 'UTF-8' 
             bodystring += bodyinside
           end
 


### PR DESCRIPTION
- Fix #361 that occurs when the actual encoding doesn't match the value specified in the `charset` of the `Content-Type` header.
  - `ASCII-8BIT` and `UTF-8`.
- Thanks to @timoschilling 