### PR TITLE
fix: guard nil lower chunk in RFC2045.haircut (#433)

### DIFF
--- a/.github/workflows/rake-test.yml
+++ b/.github/workflows/rake-test.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout the repository(CRuby)
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
       - name: Setup CRuby
         uses: ruby/setup-ruby@v1
         with:
@@ -41,8 +39,6 @@ jobs:
     steps:
       - name: Checkout the repository(JRuby)
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
       - name: Setup JRuby 
         uses: ruby/setup-ruby@v1
         with:

--- a/lib/sisimai/rfc2045.rb
+++ b/lib/sisimai/rfc2045.rb
@@ -148,6 +148,7 @@ module Sisimai
         (upperchunk, lowerchunk) = block.split("\n\n", 2)
         return ['', ''] if upperchunk.nil? || upperchunk.empty?
         return ['', ''] if upperchunk.index('Content-Type').nil?
+        lowerchunk = '' if lowerchunk.nil?
 
         headerpart = ['', ''] # ["text/plain; charset=iso-2022-jp; ...", "quoted-printable"]
         multipart1 = []       # [headerpart, "body"]

--- a/test/public/rfc2045-test.rb
+++ b/test/public/rfc2045-test.rb
@@ -156,6 +156,8 @@ I was unable to deliver your message to the following addresses:
 maria@dest.example.net
 
 Reason: 550 maria@dest.example.net... No such user'
+  MP4 = 'Content-Type: text/plain; charset=us-ascii
+Content-Transfer-Encoding: 7bit'
   def test_haircut
     cv = Sisimai::RFC2045.haircut(MP3)
     assert_instance_of Array, cv
@@ -170,6 +172,13 @@ Reason: 550 maria@dest.example.net... No such user'
     assert_equal 'text/plain; charset="utf-8"', cv[0]
     assert_equal 'quoted-printable',            cv[1]
     assert_nil Sisimai::RFC2045.haircut('')
+
+    # A part with a Content-Type header but no blank line before a body
+    cv = Sisimai::RFC2045.haircut(MP4)
+    assert_instance_of Array, cv
+    assert_equal 3, cv.size
+    assert_equal 'text/plain; charset=us-ascii', cv[0]
+    assert_equal '7bit',                         cv[1]
 
     ce = assert_raises ArgumentError do
       Sisimai::RFC2045.haircut()


### PR DESCRIPTION
A multipart part that carries a Content-Type header but no blank-line body makes block.split("\n\n", 2) return a single element, so lowerchunk becomes nil and haircut raises NoMethodError on lowerchunk.empty? at rfc2045.rb:203. This defaults lowerchunk to an empty string in that case, matching the existing nil guard for upperchunk just above. Added a haircut case for a header-only part to test/public/rfc2045-test.rb. Fixes #433.