### PR TITLE
Avoid quadratic allocations in Message.tidy

### DIFF
--- a/lib/sisimai/message.rb
+++ b/lib/sisimai/message.rb
@@ -202,7 +202,7 @@ module Sisimai
       def tidy(argv0 = '')
         return '' if argv0.empty?
 
-        email = ''
+        email = ::String.new(capacity: argv0.bytesize, encoding: Encoding::UTF_8)
         lines = argv0.split("\n")
         index = -1
         lines.each do |e|
@@ -215,7 +215,7 @@ module Sisimai
           index += 1
           if fn == ''
             # There is neither ":" character nor the field listed in $FieldTable
-            email += "#{e}\n"
+            email << e << "\n"
             next
           end
 
@@ -294,12 +294,12 @@ module Sisimai
 
           # 4. Remove redundant space characters
           bf = bf.squeeze(' ').strip
-          email += sprintf("%s: %s\n", fn, bf)
+          email << sprintf("%s: %s\n", fn, bf)
         end
 
         # 5. Convert the lower-cased SMTP command to the upper-cased.
-        email  = email.gsub("after end of data:", "after end of DATA:")
-        email += "\n" if email.end_with?("\n\n") == false
+        email.gsub!("after end of data:", "after end of DATA:")
+        email << "\n" if email.end_with?("\n\n") == false
         return email
       end
 
@@ -428,4 +428,3 @@ module Sisimai
     end
   end
 end
-

--- a/test/public/message-test.rb
+++ b/test/public/message-test.rb
@@ -161,5 +161,11 @@ __END_OF_EMAIL_MESSAGE__
 
 
   end
-end
 
+  def test_tidy_with_many_non_header_lines
+    input = (["x" * 75] * 10_000).join("\n")
+    expected = input.dup << "\n\n"
+
+    assert_equal expected, Sisimai::Message.tidy(input)
+  end
+end


### PR DESCRIPTION
## Problem

`Sisimai::Message.tidy` appends each parsed line with `String#+`. Because every append allocates and copies the accumulated output, processing time and transient memory grow quadratically for large message bodies.

## Fix

Build the output in one preallocated mutable `::String`, append with `<<`, and perform the final substitution in place. The top-level qualification is intentional because Sisimai also defines the `Sisimai::String` helper module.

The regression test exercises 10,000 non-header lines and verifies byte-identical output.

## Benchmark

Ruby 2.6.10 on a 4,734,800-byte / 62,300-line synthetic message:

| Metric | `5-stable` | Patched |
|---|---:|---:|
| `Message.tidy` elapsed | 5.249 s | 0.035 s |
| Maximum RSS | 682,852,352 bytes | 58,458,112 bytes |

The outputs were identical.

## Validation

- `rake publictest` — 153 runs, 74,468 assertions, 0 failures, 0 errors
- `RUBYOPT=--enable-frozen-string-literal ruby -I./lib ./test/public/message-test.rb` — 4 runs, 91 assertions, 0 failures, 0 errors

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 (extended thinking) via [Codex](https://openai.com/codex)